### PR TITLE
Update to wlc_view_visible_geometry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rust-wlc
 Rust bindings for [wlc](https://github.com/Cloudef/wlc), the Wayland compositor library.
 
-For wlc more recent than [651ebc8](https://github.com/Cloudef/wlc/commit/651ebc8f7da750e77fd26f09182043e7e7c036c1) (add `wlc_view_get_visible_geometry`).
+Requires wlc more recent than [651ebc8](https://github.com/Cloudef/wlc/commit/651ebc8f7da750e77fd26f09182043e7e7c036c1) (add `wlc_view_get_visible_geometry`).
 ### Rust Example
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # rust-wlc
 Rust bindings for [wlc](https://github.com/Cloudef/wlc), the Wayland compositor library.
 
+For wlc more recent than [651ebc8](https://github.com/Cloudef/wlc/commit/651ebc8f7da750e77fd26f09182043e7e7c036c1) (add `wlc_view_get_visible_geometry`).
 ### Rust Example
 
 ```rust

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -180,7 +180,7 @@ extern fn on_keyboard_key(view: WlcView, _time: u32, mods: &KeyboardModifiers, k
                 terminate();
                 return true;
             // Return key
-            } else if sym == KeySym::KeyReturn as u32 { // Execute order 66
+            } else if sym == KeySym::KeyReturn as u32 {
                 let _ = Command::new("sh")
                                 .arg("-c")
                                 .arg("/usr/bin/weston-terminal || echo a").spawn()

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -7,7 +7,7 @@ extern crate libc;
 use libc::{uintptr_t, c_char};
 
 use super::pointer_to_string;
-use super::types::{Geometry, ResizeEdge, Size, ViewType, ViewState};
+use super::types::{Geometry, ResizeEdge, Point, Size, ViewType, ViewState};
 
 #[repr(C)]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -82,6 +82,8 @@ extern "C" {
     fn wlc_view_set_mask(view: uintptr_t, mask: u32);
 
     fn wlc_view_get_geometry(view: uintptr_t) -> *const Geometry;
+
+    fn wlc_view_get_visible_geometry(view: uintptr_t, geo: *const Geometry);
 
     fn wlc_view_set_geometry(view: uintptr_t, edges: u32, geo: *const Geometry);
 
@@ -342,11 +344,20 @@ impl WlcView {
         unsafe { wlc_view_set_mask(self.0, mask); }
     }
 
-    /// Gets the geometry of the view.
+    /// Gets the geometry of the view (that the client sees).
     pub fn get_geometry(&self) -> &Geometry {
         unsafe {
             &*wlc_view_get_geometry(self.0)
         }
+    }
+
+    /// Gets the geometry of the view (that wlc displays).
+    pub fn get_visible_geometry(&self) -> Geometry {
+        let mut geo = Geometry { origin: Point { x: 0, y: 0}, size: Size { w: 0, h: 0 }};
+        unsafe {
+            wlc_view_get_visible_geometry(self.0, &mut geo);
+        }
+        return geo;
     }
 
     /// Sets the geometry of the view.


### PR DESCRIPTION
- Upates to latest wlc version (wlc from Feb 26th, 2016)
- This adds `wlc_view_get_visible_geometry`
- Adds an indicator of the wlc commit hash to the readme

Let's prepare to release this as version 0.2 on crates.io.
