### PR TITLE
Removed get_mutable_views, moved documentation to get_views

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -50,9 +50,6 @@ extern "C" {
     fn wlc_output_get_views(output: uintptr_t,
                             out_memb: *mut libc::size_t) -> *const uintptr_t;
 
-    fn  wlc_output_get_mutable_views(output: uintptr_t,
-                                     out_memb: *mut libc::size_t) -> *mut uintptr_t;
-
     fn wlc_output_set_views(output: uintptr_t, views: *const uintptr_t, memb: libc::size_t) -> bool;
 
     fn wlc_output_focus(output: uintptr_t);
@@ -186,6 +183,9 @@ impl WlcOutput {
 
     /// Get views in stack order.
     ///
+    /// This is mainly useful for wm's who need another view stack for inplace sorting.
+    /// For example tiling wms, may want to use this to keep their tiling order separated
+    /// from floating order.
     /// Returned array is a direct refeferemce, for a mutable version, see `get_mutable_views`.
     pub fn get_views(&self) -> Vec<WlcView> {
         unsafe {
@@ -208,25 +208,6 @@ impl WlcOutput {
     /// Sets the mask for this output
     pub fn set_mask(&self, mask: u32) {
         unsafe { wlc_output_set_mask(self.0, mask) }
-    }
-
-    /// Get mutable views in creation order.
-    /// This is mainly useful for wm's who need another view stack for inplace sorting.
-    /// For example tiling wms, may want to use this to keep their tiling order separated
-    /// from floating order.
-
-    /// # Safety
-    /// Returned array is a direct reference.
-    pub fn get_mutable_views(&self) -> Vec<WlcView> {
-        unsafe {
-            let mut out_memb: libc::size_t = 0;
-            let views = wlc_output_get_mutable_views(self.0, &mut out_memb);
-            let mut result = Vec::with_capacity(out_memb);
-            for index in (0 as isize) .. (out_memb as isize) {
-                result.push(WlcView(*(views.offset(index))));
-            }
-            result
-        }
     }
 
     /// Attempts to set the views of a given output.

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -186,7 +186,7 @@ impl WlcOutput {
     /// This is mainly useful for wm's who need another view stack for inplace sorting.
     /// For example tiling wms, may want to use this to keep their tiling order separated
     /// from floating order.
-    /// Returned array is a direct refeferemce, for a mutable version, see `get_mutable_views`.
+    /// This handles `wlc_output_get_views` and `wlc_output_get_mutable_views`.
     pub fn get_views(&self) -> Vec<WlcView> {
         unsafe {
             let mut out_memb: libc::size_t = 0;
@@ -208,6 +208,13 @@ impl WlcOutput {
     /// Sets the mask for this output
     pub fn set_mask(&self, mask: u32) {
         unsafe { wlc_output_set_mask(self.0, mask) }
+    }
+
+    #[deprecated]
+    /// # Deprecated
+    /// This function is equivalent to simply calling get_views
+    pub fn get_mutable_views(&self) -> Vec<WlcView> {
+        self.get_views()
     }
 
     /// Attempts to set the views of a given output.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![feature(deprecated)]
 
 //! Module defining main wlc functions.
 #![allow(improper_ctypes)] // We get warnings on WlcInterface


### PR DESCRIPTION
I checked the wlc source, the only difference between get_mutable_views and get_views is whether it returns a constant pointer or just a simple pointer. This won't matter to us, since we have to go through the FFI, and everything is immutable by default in Rust to begin with. If we want to make it mutable, we simply need the mut keyword before the let binding.

 In fact, the output of get_mutable_views would only be mutable if it's bound to a mutable variable, so that function isn't offering us any convenience whatsoever. If you have any good arguments for it I'd be happy to hear it.
