### PR TITLE
Doctest fixes

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -148,6 +148,7 @@ impl WlcOutput {
     }
 
     /// Gets the name of the WlcOutput.
+    ///
     /// Names are usually assigned in the format WLC-n,
     /// where the first output is WLC-1.
     pub fn get_name(&self) -> String {
@@ -256,6 +257,8 @@ impl WlcView {
     ///
     /// # Example
     /// ```
+    /// use rustwlc::handle::WlcView;
+    ///
     /// let view = WlcView::root();
     /// assert!(view.is_root());
     /// ```
@@ -263,7 +266,7 @@ impl WlcView {
         WlcView(0)
     }
 
-    /// Gets whether this view is the root window (desktop background).
+    /// Whether this view is the root window (desktop background).
     pub fn is_root(&self) -> bool {
         self.0 == 0
     }
@@ -272,7 +275,7 @@ impl WlcView {
     ///
     /// For the main windows of most programs, this should close the program where applicable.
     ///
-    /// # Errors
+    /// # Behavior
     /// This function will not do anything if `view.is_root()`.
     pub fn close(&self) {
         if self.is_root() { return };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,14 +44,18 @@ extern "C" {
 ///
 /// # Example
 /// ```no_run
+/// use rustwlc;
+///
 /// let interface = rustwlc::interface::WlcInterface::new();
 /// // Set a default log callback
 /// rustwlc::log_set_default_handler();
 ///
-/// if !rustwlc::init(interface) {
-///      panic!("Unable to init");
+/// if let Some(run_wlc) = rustwlc::init(interface) {
+///      run_wlc()
 /// }
-/// rustwlc::run_wlc();
+/// else {
+///      panic!("Unable to initialize wlc!");
+/// }
 /// ```
 pub fn init(interface: WlcInterface) -> Option<fn() -> ()> {
     unsafe {
@@ -68,27 +72,17 @@ pub fn init(interface: WlcInterface) -> Option<fn() -> ()> {
 /// The initialize functions will return this function in an Option.
 /// If and only if they succeed can this function be called wlc with `rustwlc::init` call this method
 /// to being wlc's main event loop.
-///
-/// # Example
-/// ```no_run
-/// use rustwlc;
-///
-/// let interface = rustwlc::interface::WlcInterface::new();
-/// rustwlc::log_set_default_handler();
-///
-/// if !rustwlc::init(interface) {
-///      panic!("Unable to init");
-/// }
-/// rustwlc::run_wlc();
-/// ```
 fn run_wlc() {
     unsafe {
         wlc_run();
     }
 }
 
-/// Executes a program in wayland.
-/// Is passed the program and all arguments (the first should be the program)
+/// Deprecated, do not use.
+///
+/// # Deprecated
+/// This function does not seem to work across the FFI boundary, and Rust provides a
+/// much better interface in the `std::command::Command` class to executing programs.
 pub fn exec(bin: String, args: Vec<String>) {
     unsafe {
         let bin_c = CString::new(bin).unwrap().as_ptr() as *const libc::c_char;
@@ -114,7 +108,22 @@ pub fn terminate() {
     }
 }
 
-/// Registers a callback for wlc logging
+/// Registers a callback for wlc logging.
+///
+/// Note that `rustwlc::log_set_default_handler()` will register a simple callback
+/// that will print the type and text to the console.
+///
+/// # Parameters
+/// The `handler` callback has two parameters:
+/// * `type`: The `LogType` of the message being printed.
+/// * `text`: The text to be logged, currently in C form. One may call `rustwlc::pointer_to_string`
+/// to convert it to a Rust String.
+///
+/// # Safety
+/// The callback function (like other callbacks in `rustwlc`) must be marked as extern as it is called
+/// from C code.
+///
+/// In addition, `unsafe` will be required to convert the text into a Rust String.
 #[allow(dead_code)]
 pub fn log_set_handler(handler: extern "C" fn(type_: LogType, text: *const libc::c_char)) {
     unsafe {
@@ -130,24 +139,40 @@ extern "C" fn default_log_callback(log_type: LogType, text: *const libc::c_char)
 
 /// Sets the wlc log callback to a simple function that prints to console.
 ///
-/// Not calling any log_set_handler will have no logging, use this or
-/// log_set_handler with a callback to use wlc logging.
+/// Not calling any `log_set_handler` will have no logging, use this or
+/// `log_set_handler` with a callback to use wlc logging.
 ///
 /// # Example
 /// ```no_run
+/// use rustwlc;
+///
 /// let interface = rustwlc::interface::WlcInterface::new();
 /// rustwlc::log_set_default_handler();
-/// if !rustwlc::init(interface) {
-///      panic!("Unable to init");
+///
+/// if let Some(run_wlc) = rustwlc::init(interface) {
+///      run_wlc();
 /// }
-/// rustwlc::run_wlc();
+/// else {
+///     panic!("Unable to initialize wlc!");
+/// }
 /// ```
 pub fn log_set_default_handler() {
     log_set_handler(default_log_callback);
 }
 
+/// Unsafe strings conversion function.
+///
 /// Converts a `*const libc::c_char` to an owned `String`.
 /// Useful for log callbacks.
+///
+/// # Example
+/// Standard usage may be for the log callbacks.
+/// ```rust
+/// extern "C" fn default_log_callback(log_type: LogType, text: *const libc::c_char) {
+///     let string = unsafe { pointer_to_string(text) };
+///     println!("wlc [{:?}]: {}", log_type, string);
+/// }
+/// ```
 pub unsafe fn pointer_to_string(pointer: *const libc::c_char) -> String {
     let slice = ffi::CStr::from_ptr(pointer);
     slice.to_string_lossy().into_owned()

--- a/src/xkb/mod.rs
+++ b/src/xkb/mod.rs
@@ -176,7 +176,7 @@ impl Keysym {
     /// ```rust
     /// use rustwlc::xkb::{Keysym, NameFlags};
     ///
-    /// let key_match_a = Keysym::from_name("a", NameFlags::None);
+    /// let key_match_a = Keysym::from_name("a".to_string(), NameFlags::None);
     /// assert!(key_match_a.is_some());
     ///
     /// let key_a = key_match_a.unwrap();
@@ -199,7 +199,7 @@ impl Keysym {
     /// ```rust
     /// use rustwlc::xkb::{Keysym, NameFlags};
     ///
-    /// let key = Keysym::from_name("a", NameFlags::None).unwrap();
+    /// let key = Keysym::from_name("a".to_string(), NameFlags::None).unwrap();
     ///
     /// assert_eq!(key.get_name(), Some("a".to_string()));
     /// ```
@@ -218,10 +218,10 @@ impl Keysym {
 
     /// Gets the Unicode/UTF8 representation of this keysym.
     pub fn to_utf8(&self) -> Option<String> {
-        let mut buffer_vec: Vec<c_char> = Vec::with_capacity(14);
+        let mut buffer_vec: Vec<c_char> = Vec::with_capacity(64);
         unsafe {
             let buffer: *mut c_char = buffer_vec.as_mut_ptr();
-            let result = xkb_keysym_to_utf8(self.0, buffer, 14);
+            let result = xkb_keysym_to_utf8(self.0, buffer, 64);
             match result {
                 -1 => None,
                 _ => Some(super::pointer_to_string(buffer))


### PR DESCRIPTION
This fixes all issues we had with running `cargo test` in the `development` branch. The problems were mostly missing imports.

At the moment, this entails a total of 21 tests: 16 which appear in the documentation of most of our modules, and 5 in the `xkb/tests.rs` file (which were written in the `xkb` branch).

These 16 tests are basically only a confirmation that our examples compile. The `xkb` doctests are not as stringent as the xkb tests module. We are still in need of actual testing in the future.
