### PR TITLE
Add a few missing wlc methods 

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -27,6 +27,9 @@ extern "C" {
 
     fn wlc_output_get_name(output: uintptr_t) -> *const c_char;
 
+    // Defined in wlc-render.h
+    fn wlc_output_schedule_render(output: uintptr_t);
+
     //fn wlc_handle_get_user_data(handle: WlcHandle) -> ();
 
     // TODO need representation of userdata
@@ -127,6 +130,15 @@ impl WlcOutput {
     /// a bug report.
     pub fn as_view(self) -> WlcView {
         return WlcView::from(self)
+    }
+
+    /// Schedules output for rendering next frame.
+    ///
+    /// If the output was already scheduled, this is
+    /// a no-op; if output is currently rendering,
+    /// it will render immediately after.
+    pub fn schedule_render(&self) {
+        unsafe { wlc_output_schedule_render(self.0) };
     }
 
     /// Gets a list of the current outputs.

--- a/src/input.rs
+++ b/src/input.rs
@@ -5,10 +5,12 @@
 #![allow(improper_ctypes)]
 
 use super::types::{KeyMod, Point};
+use libc::size_t;
 
 #[link(name = "wlc")]
 extern "C" {
-    // Keyboard functions
+    fn wlc_keyboard_get_current_keys(out_memb: *const size_t) -> *const u32;
+
     fn wlc_keyboard_get_keysym_for_key(key: u32, modifiers: &KeyMod) -> u32;
 
     fn wlc_keyboard_get_utf32_for_key(key: u32, modifiers: &KeyMod) -> u32;
@@ -42,6 +44,17 @@ pub mod keyboard {
 //! Methods for interacting with the keyboard
     use super::super::types::{KeyMod};
     use super::super::xkb::Keysym;
+    use libc::size_t;
+    use std::slice;
+
+    /// Get currently held keys.
+    pub fn get_current_keys<'a>() -> &'a[u32] {
+        let mut out_memb: size_t = 0;
+        unsafe {
+            let keys = super::wlc_keyboard_get_current_keys(&mut out_memb);
+            return slice::from_raw_parts(keys, out_memb as usize);
+        }
+    }
 
     /// Gets a keysym given a key and modifiers.
     pub fn get_keysym_for_key(key: u32, modifiers: &KeyMod) -> Keysym {

--- a/src/input.rs
+++ b/src/input.rs
@@ -48,11 +48,15 @@ pub mod keyboard {
     use std::slice;
 
     /// Get currently held keys.
-    pub fn get_current_keys<'a>() -> &'a[u32] {
+    pub fn get_current_keys() -> Vec<u32> {
         let mut out_memb: size_t = 0;
         unsafe {
             let keys = super::wlc_keyboard_get_current_keys(&mut out_memb);
-            return slice::from_raw_parts(keys, out_memb as usize);
+            let mut result = Vec::with_capacity(out_memb);
+            for index in (0 as isize) .. (out_memb as isize) {
+                result.push(*(keys.offset(index)));
+            }
+            result
         }
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -48,15 +48,11 @@ pub mod keyboard {
     use std::slice;
 
     /// Get currently held keys.
-    pub fn get_current_keys() -> Vec<u32> {
+    pub fn get_current_keys<'a>() -> &'a[u32] {
         let mut out_memb: size_t = 0;
         unsafe {
             let keys = super::wlc_keyboard_get_current_keys(&mut out_memb);
-            let mut result = Vec::with_capacity(out_memb);
-            for index in (0 as isize) .. (out_memb as isize) {
-                result.push(*(keys.offset(index)));
-            }
-            result
+            return slice::from_raw_parts(keys, out_memb as usize);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub mod input;
 pub mod wayland;
 pub mod xkb;
 
-use types::LogType;
+use types::{BackendType, LogType};
 use interface::WlcInterface;
 
 // External WLC functions
@@ -34,6 +34,18 @@ extern "C" {
     fn wlc_terminate();
 
     fn wlc_log_set_handler(callback: extern "C" fn(log_type: LogType, text: *const libc::c_char));
+
+    fn wlc_get_backend_type() -> BackendType;
+}
+
+/// Query backend wlc is using.
+///
+/// # Results
+/// * None: Unknown backend type
+/// * DRM: "Direct Rendering Manager" - running on tty
+/// * X11: Running inside an X server
+pub fn get_backend_type() -> BackendType {
+    unsafe { wlc_get_backend_type() }
 }
 
 /// Initialize wlc with a `WlcInterface`.

--- a/src/xkb/mod.rs
+++ b/src/xkb/mod.rs
@@ -137,6 +137,25 @@ pub enum NameFlags {
     CaseInsensitive = 1
 }
 
+/// Opaque keyboard state object.
+///
+/// State objects contain the active state of a keyboard (or keyboards), such
+/// as the currently effective layout and the active modifiers.  It acts as a
+/// simple state machine, wherein key presses and releases are the input, and
+/// key symbols (keysyms) are the output.
+#[repr(C)]
+pub struct XKBState;
+
+/// Opaque compiled keymap object.
+///
+/// The keymap object holds all of the static keyboard information obtained
+/// from compiling XKB files.
+///
+/// A keymap is immutable after it is created (besides reference counts, etc.);
+/// if you need to change it, you must create a new one.
+#[repr(C)]
+pub struct XKBKeymap;
+
 #[link(name = "xkbcommon")]
 extern "C" {
     fn xkb_keysym_get_name(keysym: u32, buffer: *mut c_char, size: size_t) -> i32;
@@ -149,7 +168,6 @@ extern "C" {
 }
 
 impl Keysym {
-
     /// Whether this keysym is valid or is `XKB_KEY_NoSymbol`
     pub fn is_valid(&self) -> bool {
         self.0 != 0 && self.0 != 0xffffffff


### PR DESCRIPTION
The methods added are:
- `rustwlc::get_backend_type() -> BackendType`
- `WlcOutput::schedule_render(&self)`
- `input::keyboard::get_current_keys() -> &[u32]`

This also adds `XKBKeyState` and `XKBKeymap` empty structs to the xkb module. These do not currently have a use and in future versions may be moved into a separate Rust xkbcommon library.
