### PR TITLE
Add get/set_user_data to WlcView and WlcOutput

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -334,6 +334,22 @@ impl WlcView {
         self.0 != 0
     }
 
+    /// Gets user-specified data.
+    ///
+    /// This function is used by wlc itself and we can only
+    /// guarantee a `*mut c_void`. Use at your own risk.
+    pub unsafe fn get_user_data(&self) -> *mut c_void {
+        wlc_handle_get_user_data(self.0)
+    }
+
+    /// Sets user-specified data.
+    ///
+    /// This function is used by wlc itself and we can only
+    /// guarantee a `*mut c_void`. Use at your own risk.
+    pub unsafe fn set_user_data(&self, data: *const c_void) {
+        wlc_handle_set_user_data(self.0, data);
+    }
+
     /// Closes this view.
     ///
     /// For the main windows of most programs, this should close the program where applicable.

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -4,7 +4,7 @@
 #![allow(improper_ctypes)]
 
 extern crate libc;
-use libc::{uintptr_t, c_char};
+use libc::{uintptr_t, c_char, c_void};
 
 use super::pointer_to_string;
 use super::types::{Geometry, ResizeEdge, Point, Size, ViewType, ViewState};
@@ -27,10 +27,9 @@ extern "C" {
 
     fn wlc_output_get_name(output: uintptr_t) -> *const c_char;
 
-    //fn wlc_handle_get_user_data(handle: WlcHandle) -> ();
+    fn wlc_handle_get_user_data(handle: uintptr_t) -> *mut c_void;
 
-    // TODO need representation of userdata
-    //fn wlc_handle_set_user_data(handle: WlcHandle, userdata: ?????) -> ();
+    fn wlc_handle_set_user_data(handle: uintptr_t, userdata: *const c_void);
 
     fn wlc_output_get_sleep(output: uintptr_t) -> bool;
 
@@ -128,6 +127,15 @@ impl WlcOutput {
     pub fn as_view(self) -> WlcView {
         return WlcView::from(self)
     }
+
+    /*
+    pub fn get_user_data<T>(&self) -> &mut T {
+        
+    }
+
+    pub fn set_user_data<T>(&self, T) {
+        
+    }*/
 
     /// Gets a list of the current outputs.
     pub fn list() -> Vec<WlcOutput> {

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -131,14 +131,21 @@ impl WlcOutput {
         return WlcView::from(self)
     }
 
-    /*
-    pub fn get_user_data<T>(&self) -> &mut T {
-        
+    /// Gets user-specified data.
+    ///
+    /// This function is used by wlc itself and we can only
+    /// guarantee a `*mut c_void`. Use at your own risk.
+    pub unsafe fn get_user_data(&self) -> *mut c_void {
+        wlc_handle_get_user_data(self.0)
     }
 
-    pub fn set_user_data<T>(&self, T) {
-        
-    }*/
+    /// Sets user-specified data.
+    ///
+    /// This function is used by wlc itself and we can only
+    /// guarantee a `*mut c_void`. Use at your own risk.
+    pub unsafe fn set_user_data(&self, data: *const c_void) {
+        wlc_handle_set_user_data(self.0, data);
+    }
 
     /// Schedules output for rendering next frame.
     ///

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -131,7 +131,6 @@ impl WlcOutput {
         return WlcView::from(self)
     }
 
-<<<<<<< HEAD
     /*
     pub fn get_user_data<T>(&self) -> &mut T {
         
@@ -141,7 +140,6 @@ impl WlcOutput {
         
     }*/
 
-=======
     /// Schedules output for rendering next frame.
     ///
     /// If the output was already scheduled, this is
@@ -151,7 +149,6 @@ impl WlcOutput {
         unsafe { wlc_output_schedule_render(self.0) };
     }
 
->>>>>>> master
     /// Gets a list of the current outputs.
     pub fn list() -> Vec<WlcOutput> {
         unsafe {

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -133,18 +133,34 @@ impl WlcOutput {
 
     /// Gets user-specified data.
     ///
-    /// This function is used by wlc itself and we can only
-    /// guarantee a `*mut c_void`. Use at your own risk.
-    pub unsafe fn get_user_data(&self) -> *mut c_void {
-        wlc_handle_get_user_data(self.0)
+    /// # Unsafety
+    /// The wlc implementation of this method uses `void*` pointers
+    /// for raw C data. This function will internaly do a conversion
+    /// between the input `T` and a `libc::c_void`.
+    ///
+    /// This is a highly unsafe conversion with no guarantees. As
+    /// such, usage of these functions requires an understanding of
+    /// what data they will have. Please review wlc's usage of these
+    /// functions before attempting to use them yourself.
+    pub unsafe fn get_user_data<T>(&self) -> &mut T {
+        let raw_data = wlc_handle_get_user_data(self.0);
+        return &mut *(raw_data as *mut T);
     }
 
     /// Sets user-specified data.
     ///
-    /// This function is used by wlc itself and we can only
-    /// guarantee a `*mut c_void`. Use at your own risk.
-    pub unsafe fn set_user_data(&self, data: *const c_void) {
-        wlc_handle_set_user_data(self.0, data);
+    /// # Unsafety
+    /// The wlc implementation of this method uses `void*` pointers
+    /// for raw C data. This function will internaly do a conversion
+    /// between the input `T` and a `libc::c_void`.
+    ///
+    /// This is a highly unsafe conversion with no guarantees. As
+    /// such, usage of these functions requires an understanding of
+    /// what data they will have. Please review wlc's usage of these
+    /// functions before attempting to use them yourself.
+    pub unsafe fn set_user_data<T>(&self, data: &T) {
+        let data_ptr: *const c_void = data as *const _ as *const c_void;
+        wlc_handle_set_user_data(self.0, data_ptr);
     }
 
     /// Schedules output for rendering next frame.
@@ -336,18 +352,34 @@ impl WlcView {
 
     /// Gets user-specified data.
     ///
-    /// This function is used by wlc itself and we can only
-    /// guarantee a `*mut c_void`. Use at your own risk.
-    pub unsafe fn get_user_data(&self) -> *mut c_void {
-        wlc_handle_get_user_data(self.0)
+    /// # Unsafety
+    /// The wlc implementation of this method uses `void*` pointers
+    /// for raw C data. This function will internaly do a conversion
+    /// between the input `T` and a `libc::c_void`.
+    ///
+    /// This is a highly unsafe conversion with no guarantees. As
+    /// such, usage of these functions requires an understanding of
+    /// what data they will have. Please review wlc's usage of these
+    /// functions before attempting to use them yourself.
+    pub unsafe fn get_user_data<T>(&self) -> &mut T {
+        let raw_data = wlc_handle_get_user_data(self.0);
+        return &mut *(raw_data as *mut T);
     }
 
     /// Sets user-specified data.
     ///
-    /// This function is used by wlc itself and we can only
-    /// guarantee a `*mut c_void`. Use at your own risk.
-    pub unsafe fn set_user_data(&self, data: *const c_void) {
-        wlc_handle_set_user_data(self.0, data);
+    /// # Unsafety
+    /// The wlc implementation of this method uses `void*` pointers
+    /// for raw C data. This function will internaly do a conversion
+    /// between the input `T` and a `libc::c_void`.
+    ///
+    /// This is a highly unsafe conversion with no guarantees. As
+    /// such, usage of these functions requires an understanding of
+    /// what data they will have. Please review wlc's usage of these
+    /// functions before attempting to use them yourself.
+    pub unsafe fn set_user_data<T>(&self, data: &T) {
+        let data_ptr: *const c_void = data as *const _ as *const c_void;
+        wlc_handle_set_user_data(self.0, data_ptr);
     }
 
     /// Closes this view.


### PR DESCRIPTION
This merge adds implementations of `wlc_handle_get_userdata` and `wlc_handle_set_userdata` to WlcView and WlcOutput.

These methods are declared `unsafe` and do use ~~raw `libc::c_void` pointers~~ highly unsafe convenience casts that the user must figure out. We do not want to make any safety guarantees about these methods. Library users wishing to use these methods **will** have to use unsafe Rust code.
