### PR TITLE
Fix bitflags and annotations

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,8 +1,5 @@
 //! Contains definitions for wlc handle types.
 
-// We get warnings for the bitflags, which are described in the crate as C-safe...
-#![allow(improper_ctypes)]
-
 extern crate libc;
 use libc::{uintptr_t, c_char, c_void};
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,9 +1,6 @@
 //! Contains methods for interacting with the pointer
 //! and keyboard of wlc.
 
-// We get warnings for &Keymod, which uses bitflags.
-#![allow(improper_ctypes)]
-
 use super::types::{KeyMod, Point};
 use libc::size_t;
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,9 +1,6 @@
 //! Contains callback-holding struct `WlcInterface` which is used
 //! to initialize wlc.
 
-// We get warnings on WlcInterface. It has a #[repr(C)] on it...
-#![allow(improper_ctypes)]
-
 extern crate libc;
 
 use std::option::Option;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
-#![warn(missing_docs)]
-
 //! Module defining main wlc functions.
-#![allow(improper_ctypes)] // We get warnings on WlcInterface
+
+#![warn(missing_docs)]
 
 extern crate libc;
 
@@ -24,9 +23,13 @@ use interface::WlcInterface;
 
 // External WLC functions
 #[link(name = "wlc")]
+#[allow(improper_ctypes)] // Because the annotation on wlc_init wasn't enough
 extern "C" {
     fn wlc_exec(bin: *const libc::c_char, args: *const *const libc::c_char);
 
+    // This is giving us a "found zero-size struct in foreign module" for the WlcInterface.
+    // The interface itself has a #[repr(C)] and builds fine...
+    #[allow(improper_ctypes)]
     fn wlc_init(interface: *const WlcInterface, argc: i32, argv: *const *mut libc::c_char) -> bool;
 
     fn wlc_run();

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,11 +1,7 @@
 //! Contains struct and enum declarations for
 //! structs defined by the wlc protocl.
 
-// Bitflags can't work well with docs
-#![allow(missing_docs)]
 use std::fmt;
-
-// Types
 
 /// Log level to pass into wlc logging
 #[repr(C)]
@@ -33,9 +29,9 @@ pub enum BackendType {
     X11
 }
 
-/// Bitflags describing wayland events
-#[repr(C)]
 bitflags! {
+    /// Flags describing wayland events
+    #[repr(C)]
     flags EventBit: u32 {
         /// Event can be read
         const EVENT_READABLE = 1,
@@ -48,9 +44,9 @@ bitflags! {
     }
 }
 
-/// How and window is being viewed
-#[repr(C)]
 bitflags! {
+    /// How window is being viewed
+    #[repr(C)]
     flags ViewState: u32 {
         /// Window maximized
         const VIEW_MAXIMIZED = 1,
@@ -65,9 +61,9 @@ bitflags! {
     }
 }
 
-/// Viewtype - like x11 flags
-#[repr(C)]
 bitflags! {
+    /// Viewtype - like x11 flags
+    #[repr(C)]
     flags ViewType: u32 {
         /// Override redirect (X11)
         const VIEW_BIT_OVERRIDE_REDIRECT = 1,
@@ -82,9 +78,9 @@ bitflags! {
     }
 }
 
-// Which edge is being used to resize a window.
-#[repr(C)]
 bitflags! {
+    /// Which edge is being used to resize a window.
+    #[repr(C)]
     flags ResizeEdge: u32 {
         /// No edge
         const EDGE_NONE = 0,
@@ -107,9 +103,9 @@ bitflags! {
     }
 }
 
-/// Represents which keyboard meta keys are being pressed.
-#[repr(C)]
 bitflags! {
+    /// Represents which keyboard meta keys are being pressed.
+    #[repr(C)]
     flags KeyMod: u32 {
         /// No modifiers
         const MOD_NONE = 0,
@@ -120,7 +116,7 @@ bitflags! {
         /// Control
         const MOD_CTRL = 4,
         /// Alt
-        const MOD_ALT= 8,
+        const MOD_ALT = 8,
         /// Mod2
         const MOD_MOD2 = 16,
         /// Mod3
@@ -132,10 +128,10 @@ bitflags! {
     }
 }
 
-/// "LEDs" or active key-locks.
-/// i.e. caps lock, scroll lock
-#[repr(C)]
 bitflags! {
+    /// "LEDs" or active key-locks.
+    /// i.e. caps lock, scroll lock
+    #[repr(C)]
     flags KeyboardLed: u32 {
         /// Num lock is pressed
         const NUM_LOCK = 1,
@@ -192,7 +188,7 @@ pub enum TouchType {
     Motion,
     /// Touch frame
     Frame,
-    /// Touch cancelled 
+    /// Touch cancelled
     Cancel
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -137,8 +137,13 @@ bitflags! {
         const NUM_LOCK = 1,
         /// Caps lock is pressed
         const CAPS_LOCK = 2,
-        /// Scroll lock is pressed
-        const SCROL_LLOCK = 4
+        /// Original typo of SCROLL_LOCK
+        ///
+        /// # Deprecated
+        /// Please use SCROLL_LOCK instead.
+        const SCROL_LLOCK = 4,
+        /// Scroll lock key is being pressed.
+        const SCROLL_LOCK = 4
     }
 }
 


### PR DESCRIPTION
Turns out you're supposed to put annotations _inside_ the `bitflags!` macro.

This also means we can get rid of all the module-level `#![allow(unsafe_ctypes)]` annotations. In the future we should avoid module-level `#[allow]`s (except for `xkb/keysyms` for however long that stays around).

Also found a typo with one of the flags, added another properly-spelled constant (see 7e906e1).
