### PR TITLE
Traitify

### DIFF
--- a/src/callback.rs
+++ b/src/callback.rs
@@ -145,7 +145,7 @@ extern "C" {
 ///
 /// # Example
 /// ```rust
-/// use rustwlc::{WlcOutput, WlcOutputable};
+/// use rustwlc::{WlcOutput, Output};
 ///
 /// extern fn on_output_created(output: WlcOutput) -> bool {
 ///     println!("Output {} ({:?}) was created", output.get_name(), output);
@@ -180,7 +180,7 @@ pub fn output_destroyed(callback: extern "C" fn(output: WlcOutput)) {
 ///
 /// # Example
 /// ```rust
-/// use rustwlc::{WlcOutput, WlcOutputable};
+/// use rustwlc::{WlcOutput, Output};
 ///
 /// extern fn output_focus(output: WlcOutput, focused: bool) {
 ///     println!("Output {} {} focus", output.get_name(),
@@ -198,7 +198,7 @@ pub fn output_focus(callback: extern "C" fn(output: WlcOutput, focused: bool)) {
 ///
 /// # Example
 /// ```rust
-/// use rustwlc::{WlcOutput, WlcOutputable};
+/// use rustwlc::{WlcOutput, Output};
 /// use rustwlc::Size;
 ///
 /// extern fn output_resolution(output: WlcOutput,
@@ -254,7 +254,7 @@ pub fn output_render_post(callback: extern "C" fn(output: WlcOutput)) {
 ///
 /// # Example
 /// ```rust
-/// use rustwlc::{WlcView, WlcViewable, WlcOutputable};
+/// use rustwlc::{WlcView, View, Output};
 ///
 /// extern fn view_created(view: WlcView) -> bool {
 ///     println!("View \"{}\" was created ({:?})", view.get_class(), view);
@@ -297,7 +297,7 @@ pub fn view_destroyed(callback: extern "C" fn(view: WlcView)) {
 ///
 /// # Example
 /// ```rust
-/// use rustwlc::{WlcView, WlcViewable};
+/// use rustwlc::{WlcView, View};
 /// // The bitflags constants need to be imported manually.
 /// use rustwlc::VIEW_ACTIVATED;
 ///

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -145,7 +145,7 @@ extern "C" {
 ///
 /// # Example
 /// ```rust
-/// use rustwlc::WlcOutput;
+/// use rustwlc::{WlcOutput, WlcOutputable};
 ///
 /// extern fn on_output_created(output: WlcOutput) -> bool {
 ///     println!("Output {} ({:?}) was created", output.get_name(), output);
@@ -180,7 +180,7 @@ pub fn output_destroyed(callback: extern "C" fn(output: WlcOutput)) {
 ///
 /// # Example
 /// ```rust
-/// use rustwlc::WlcOutput;
+/// use rustwlc::{WlcOutput, WlcOutputable};
 ///
 /// extern fn output_focus(output: WlcOutput, focused: bool) {
 ///     println!("Output {} {} focus", output.get_name(),
@@ -198,7 +198,7 @@ pub fn output_focus(callback: extern "C" fn(output: WlcOutput, focused: bool)) {
 ///
 /// # Example
 /// ```rust
-/// use rustwlc::WlcOutput;
+/// use rustwlc::{WlcOutput, WlcOutputable};
 /// use rustwlc::Size;
 ///
 /// extern fn output_resolution(output: WlcOutput,
@@ -254,7 +254,7 @@ pub fn output_render_post(callback: extern "C" fn(output: WlcOutput)) {
 ///
 /// # Example
 /// ```rust
-/// use rustwlc::WlcView;
+/// use rustwlc::{WlcView, WlcViewable, WlcOutputable};
 ///
 /// extern fn view_created(view: WlcView) -> bool {
 ///     println!("View \"{}\" was created ({:?})", view.get_class(), view);
@@ -297,7 +297,7 @@ pub fn view_destroyed(callback: extern "C" fn(view: WlcView)) {
 ///
 /// # Example
 /// ```rust
-/// use rustwlc::WlcView;
+/// use rustwlc::{WlcView, WlcViewable};
 /// // The bitflags constants need to be imported manually.
 /// use rustwlc::VIEW_ACTIVATED;
 ///

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -12,13 +12,13 @@ use super::pointer_to_string;
 use super::types::{Geometry, ResizeEdge, Point, Size, ViewType, ViewState};
 
 #[repr(C)]
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// Represents a handle to a wlc view.
 ///
 pub struct WlcView(libc::uintptr_t);
 
 #[repr(C)]
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// Represents a handle to a wlc output.
 pub struct WlcOutput(libc::uintptr_t);
 

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -11,6 +11,9 @@ use libc::{uintptr_t, c_char, c_void};
 use super::pointer_to_string;
 use super::types::{Geometry, ResizeEdge, Point, Size, ViewType, ViewState};
 
+use std::hash::Hash;
+use std::fmt::Debug;
+
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// Represents a handle to a wlc view.
@@ -124,7 +127,7 @@ impl From<WlcOutput> for WlcView {
 
 /// A trait defining the methods on a wlc output handle.
 /// This trait is exposed to aid testing when wlc isn't running
-pub trait Output {
+pub trait Output: Debug + Clone + Copy + PartialEq + Eq + PartialOrd + Ord + Hash {
 
     /// Compatability/debugging function.
     ///
@@ -218,7 +221,7 @@ pub trait Output {
 
 /// A trait defining the methods on a wlc view handle.
 /// This trait is exposed to aid testing when wlc isn't running
-pub trait View {
+pub trait View: Debug + Clone + Copy + PartialEq + Eq + PartialOrd + Ord + Hash  {
 
     /// Compatability/debugging function.
     ///

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -124,7 +124,7 @@ impl From<WlcOutput> for WlcView {
 
 /// A trait defining the methods on a wlc output handle.
 /// This trait is exposed to aid testing when wlc isn't running
-pub trait WlcOutputable {
+pub trait Output {
 
     /// Compatability/debugging function.
     ///
@@ -218,7 +218,7 @@ pub trait WlcOutputable {
 
 /// A trait defining the methods on a wlc view handle.
 /// This trait is exposed to aid testing when wlc isn't running
-pub trait WlcViewable {
+pub trait View {
 
     /// Compatability/debugging function.
     ///
@@ -232,7 +232,7 @@ pub trait WlcViewable {
     ///
     /// # Example
     /// ```rust
-    /// # use rustwlc::{WlcView, WlcViewable};
+    /// # use rustwlc::{WlcView, View};
     /// # // This example can be run because WlcView::root() does not interact with wlc
     /// let view = WlcView::root();
     /// assert!(view.is_root());
@@ -247,7 +247,7 @@ pub trait WlcViewable {
     ///
     /// # Example
     /// ```rust
-    /// # use rustwlc::{WlcView, WlcViewable};
+    /// # use rustwlc::{WlcView, View};
     /// let view = WlcView::root();
     /// assert!(view.is_root());
     /// assert!(!view.is_window());
@@ -433,7 +433,7 @@ impl WlcOutput {
 
 }
 
-impl WlcOutputable for WlcOutput {
+impl Output for WlcOutput {
 
     /// Compatability/debugging function.
     ///
@@ -617,7 +617,7 @@ impl WlcView {
     ///
     /// # Example
     /// ```
-    /// # use rustwlc::{WlcView, WlcViewable};
+    /// # use rustwlc::{WlcView, View};
     /// let view = WlcView::root();
     /// assert!(view.is_root());
     /// ```
@@ -627,7 +627,7 @@ impl WlcView {
 
 }
 
-impl WlcViewable for WlcView {
+impl View for WlcView {
 
     /// Compatability/debugging function.
     ///
@@ -643,7 +643,7 @@ impl WlcViewable for WlcView {
     ///
     /// # Example
     /// ```rust
-    /// # use rustwlc::{WlcView, WlcViewable};
+    /// # use rustwlc::{WlcView, View};
     /// # // This example can be run because WlcView::root() does not interact with wlc
     /// let view = WlcView::root();
     /// assert!(view.is_root());
@@ -660,7 +660,7 @@ impl WlcViewable for WlcView {
     ///
     /// # Example
     /// ```rust
-    /// # use rustwlc::{WlcView, WlcViewable};
+    /// # use rustwlc::{WlcView, View};
     /// let view = WlcView::root();
     /// assert!(view.is_root());
     /// assert!(!view.is_window());

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -122,7 +122,9 @@ impl From<WlcOutput> for WlcView {
     }
 }
 
-impl WlcOutput {
+/// A trait defining the methods on a wlc output handle.
+/// This trait is exposed to aid testing when wlc isn't running
+pub trait WlcOutputable {
 
     /// Compatability/debugging function.
     ///
@@ -130,9 +132,240 @@ impl WlcOutput {
     /// If for some reason a conversion between the two was required,
     /// this function could be called. If this is the case please submit
     /// a bug report.
-    pub fn as_view(self) -> WlcView {
-        return WlcView::from(self)
-    }
+    fn as_view(self) -> WlcView;
+
+    /// Gets user-specified data.
+    ///
+    /// # Unsafety
+    /// The wlc implementation of this method uses `void*` pointers
+    /// for raw C data. This function will internaly do a conversion
+    /// between the input `T` and a `libc::c_void`.
+    ///
+    /// This is a highly unsafe conversion with no guarantees. As
+    /// such, usage of these functions requires an understanding of
+    /// what data they will have. Please review wlc's usage of these
+    /// functions before attempting to use them yourself.
+    unsafe fn get_user_data<T>(&self) -> &mut T;
+
+    /// Sets user-specified data.
+    ///
+    /// # Unsafety
+    /// The wlc implementation of this method uses `void*` pointers
+    /// for raw C data. This function will internaly do a conversion
+    /// between the input `T` and a `libc::c_void`.
+    ///
+    /// This is a highly unsafe conversion with no guarantees. As
+    /// such, usage of these functions requires an understanding of
+    /// what data they will have. Please review wlc's usage of these
+    /// functions before attempting to use them yourself.
+    unsafe fn set_user_data<T>(&self, data: &T);
+
+    /// Schedules output for rendering next frame.
+    ///
+    /// If the output was already scheduled, this is
+    /// a no-op; if output is currently rendering,
+    /// it will render immediately after.
+    fn schedule_render(&self);
+
+    /// Gets the name of the WlcOutput.
+    ///
+    /// Names are usually assigned in the format WLC-n,
+    /// where the first output is WLC-1.
+    fn get_name(&self) -> String;
+
+    /// Gets the sleep status of the output.
+    ///
+    /// Returns `true` if the monitor is sleeping,
+    /// such as having been set with `set_sleep`.
+    fn get_sleep(&self) -> bool;
+
+    /// Sets the sleep status of the output.
+    fn set_sleep(&self, sleep: bool);
+
+    /// Gets the output resolution in pixels.
+    fn get_resolution(&self) -> &Size;
+
+    /// Sets the resolution of the output.
+    ///
+    /// # Safety
+    /// This method will crash the program if use when wlc is not running.
+    fn set_resolution(&self, size: Size);
+
+    /// Get views in stack order.
+    ///
+    /// This is mainly useful for wm's who need another view stack for inplace sorting.
+    /// For example tiling wms, may want to use this to keep their tiling order separated
+    /// from floating order.
+    /// This handles `wlc_output_get_views` and `wlc_output_get_mutable_views`.
+    fn get_views(&self) -> Vec<WlcView>;
+
+    /// Gets the mask of this output
+    fn get_mask(&self) -> u32;
+
+    /// Sets the mask for this output
+    fn set_mask(&self, mask: u32);
+
+    /// # Deprecated
+    /// This function is equivalent to simply calling get_views
+    fn get_mutable_views(&self) -> Vec<WlcView>;
+
+    /// Attempts to set the views of a given output.
+    ///
+    /// Returns success if operation succeeded. An error will be returned
+    /// if something went wrong or if wlc isn't running.
+    fn set_views(&self, views: &mut Vec<&WlcView>) -> Result<(), &'static str>;
+}
+
+/// A trait defining the methods on a wlc view handle.
+/// This trait is exposed to aid testing when wlc isn't running
+pub trait WlcViewable {
+
+    /// Compatability/debugging function.
+    ///
+    /// wlc internally stores views and outputs under the same type.
+    /// If for some reason a conversion between the two was required,
+    /// this function could be called. If this is the case please submit
+    /// a bug report.
+    fn as_output(self) -> WlcOutput;
+
+    /// Whether this view is the root window (desktop background).
+    ///
+    /// # Example
+    /// ```rust
+    /// # use rustwlc::{WlcView, WlcViewable};
+    /// # // This example can be run because WlcView::root() does not interact with wlc
+    /// let view = WlcView::root();
+    /// assert!(view.is_root());
+    /// ```
+    #[inline]
+    fn is_root(&self) -> bool;
+
+    /// Whether this view is not the root window (desktop background).
+    ///
+    /// # Usage
+    /// A convenience method, the opposite of `view.is_root()`.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use rustwlc::{WlcView, WlcViewable};
+    /// let view = WlcView::root();
+    /// assert!(view.is_root());
+    /// assert!(!view.is_window());
+    /// ```
+    #[inline]
+    fn is_window(&self) -> bool;
+
+    /// Gets user-specified data.
+    ///
+    /// # Unsafety
+    /// The wlc implementation of this method uses `void*` pointers
+    /// for raw C data. This function will internaly do a conversion
+    /// between the input `T` and a `libc::c_void`.
+    ///
+    /// This is a highly unsafe conversion with no guarantees. As
+    /// such, usage of these functions requires an understanding of
+    /// what data they will have. Please review wlc's usage of these
+    /// functions before attempting to use them yourself.
+    unsafe fn get_user_data<T>(&self) -> &mut T;
+
+    /// Sets user-specified data.
+    ///
+    /// # Unsafety
+    /// The wlc implementation of this method uses `void*` pointers
+    /// for raw C data. This function will internaly do a conversion
+    /// between the input `T` and a `libc::c_void`.
+    ///
+    /// This is a highly unsafe conversion with no guarantees. As
+    /// such, usage of these functions requires an understanding of
+    /// what data they will have. Please review wlc's usage of these
+    /// functions before attempting to use them yourself.
+    unsafe fn set_user_data<T>(&self, data: &T);
+
+    /// Closes this view.
+    ///
+    /// For the main windows of most programs, this should close the program where applicable.
+    ///
+    /// # Behavior
+    /// This function will not do anything if `view.is_root()`.
+    fn close(&self);
+
+    /// Gets the WlcOutput this view is currently part of.
+    fn get_output(&self) -> WlcOutput;
+
+    /// Sets the output that the view renders on.
+    ///
+    /// This may not be supported by wlc at this time.
+    fn set_output(&self, output: &WlcOutput);
+
+    /// Brings this view to focus.
+    ///
+    /// Can be called on `WlcView::root()` to lose all focus.
+    fn focus(&self);
+
+    /// Sends the view to the back of the compositor
+    fn send_to_back(&self);
+
+    /// Sends this view underneath another.
+    fn send_below(&self, other: &WlcView);
+
+    /// Brings this view above another.
+    fn bring_above(&self, other: &WlcView);
+
+    /// Brings this view to the front of the stack
+    /// within its WlcOutput.
+    fn bring_to_front(&self);
+
+    // TODO Get masks enum working properly
+    /// Gets the current visibilty bitmask for the view.
+    fn get_mask(&self) -> u32;
+
+    // TODO Get masks enum working properly
+    /// Sets the visibilty bitmask for the view.
+    fn set_mask(&self, mask: u32);
+
+    /// Gets the geometry of the view.
+    fn get_geometry(&self) -> Option<&Geometry>;
+
+    /// Gets the geometry of the view (that wlc displays).
+    fn get_visible_geometry(&self) -> Geometry;
+
+    /// Sets the geometry of the view.
+    ///
+    /// Set edges if geometry is caused by interactive resize.
+    fn set_geometry(&self, edges: ResizeEdge, geometry: &Geometry);
+
+    /// Gets the type bitfield of the curent view
+    fn get_type(&self) -> ViewType;
+
+    /// Set flag in the type field. Toggle indicates whether it is set.
+    fn set_type(&self, view_type: ViewType, toggle: bool);
+
+    // TODO get bitflags enums
+    /// Get the current ViewState bitfield.
+    fn get_state(&self) -> ViewState;
+
+    /// Set ViewState bit. Toggle indicates whether it is set or not.
+    fn set_state(&self, state: ViewState, toggle: bool);
+
+    /// Gets parent view, returns `WlcView::root()` if this view has no parent.
+    fn get_parent(&self) -> WlcView;
+
+    /// Set the parent of this view.
+    ///
+    /// Call with `WlcView::root()` to make its parent the root window.
+    fn set_parent(&self, parent: &WlcView);
+
+    /// Get the title of the view
+    fn get_title(&self) -> String;
+
+    /// Get class (shell surface only).
+    fn get_class(&self) -> String;
+
+    /// Get app id (xdg-surface only).
+    fn get_app_id(&self) -> String;
+}
+
+impl WlcOutput {
 
     /// Create a dummy WlcOutput for testing purposes.
     ///
@@ -157,47 +390,6 @@ impl WlcOutput {
     /// ```
     pub fn dummy(code: u32) -> WlcOutput {
         WlcOutput(code as libc::uintptr_t)
-    }
-
-    /// Gets user-specified data.
-    ///
-    /// # Unsafety
-    /// The wlc implementation of this method uses `void*` pointers
-    /// for raw C data. This function will internaly do a conversion
-    /// between the input `T` and a `libc::c_void`.
-    ///
-    /// This is a highly unsafe conversion with no guarantees. As
-    /// such, usage of these functions requires an understanding of
-    /// what data they will have. Please review wlc's usage of these
-    /// functions before attempting to use them yourself.
-    pub unsafe fn get_user_data<T>(&self) -> &mut T {
-        let raw_data = wlc_handle_get_user_data(self.0);
-        return &mut *(raw_data as *mut T);
-    }
-
-    /// Sets user-specified data.
-    ///
-    /// # Unsafety
-    /// The wlc implementation of this method uses `void*` pointers
-    /// for raw C data. This function will internaly do a conversion
-    /// between the input `T` and a `libc::c_void`.
-    ///
-    /// This is a highly unsafe conversion with no guarantees. As
-    /// such, usage of these functions requires an understanding of
-    /// what data they will have. Please review wlc's usage of these
-    /// functions before attempting to use them yourself.
-    pub unsafe fn set_user_data<T>(&self, data: &T) {
-        let data_ptr: *const c_void = data as *const _ as *const c_void;
-        wlc_handle_set_user_data(self.0, data_ptr);
-    }
-
-    /// Schedules output for rendering next frame.
-    ///
-    /// If the output was already scheduled, this is
-    /// a no-op; if output is currently rendering,
-    /// it will render immediately after.
-    pub fn schedule_render(&self) {
-        unsafe { wlc_output_schedule_render(self.0) };
     }
 
     /// Gets a list of the current outputs.
@@ -227,11 +419,78 @@ impl WlcOutput {
         unsafe { WlcOutput(wlc_get_focused_output()) }
     }
 
+    /// Focuses compositor on a specific output.
+    ///
+    /// Pass in Option::None for no focus.
+    pub fn focus(output: Option<&WlcOutput>) {
+        unsafe {
+            match output {
+                Some(output) => wlc_output_focus(output.0),
+                None => wlc_output_focus(0)
+            }
+        }
+    }
+
+}
+
+impl WlcOutputable for WlcOutput {
+
+    /// Compatability/debugging function.
+    ///
+    /// wlc internally stores views and outputs under the same type.
+    /// If for some reason a conversion between the two was required,
+    /// this function could be called. If this is the case please submit
+    /// a bug report.
+    fn as_view(self) -> WlcView {
+        return WlcView::from(self)
+    }
+
+    /// Gets user-specified data.
+    ///
+    /// # Unsafety
+    /// The wlc implementation of this method uses `void*` pointers
+    /// for raw C data. This function will internaly do a conversion
+    /// between the input `T` and a `libc::c_void`.
+    ///
+    /// This is a highly unsafe conversion with no guarantees. As
+    /// such, usage of these functions requires an understanding of
+    /// what data they will have. Please review wlc's usage of these
+    /// functions before attempting to use them yourself.
+    unsafe fn get_user_data<T>(&self) -> &mut T {
+        let raw_data = wlc_handle_get_user_data(self.0);
+        return &mut *(raw_data as *mut T);
+    }
+
+    /// Sets user-specified data.
+    ///
+    /// # Unsafety
+    /// The wlc implementation of this method uses `void*` pointers
+    /// for raw C data. This function will internaly do a conversion
+    /// between the input `T` and a `libc::c_void`.
+    ///
+    /// This is a highly unsafe conversion with no guarantees. As
+    /// such, usage of these functions requires an understanding of
+    /// what data they will have. Please review wlc's usage of these
+    /// functions before attempting to use them yourself.
+    unsafe fn set_user_data<T>(&self, data: &T) {
+        let data_ptr: *const c_void = data as *const _ as *const c_void;
+        wlc_handle_set_user_data(self.0, data_ptr);
+    }
+
+    /// Schedules output for rendering next frame.
+    ///
+    /// If the output was already scheduled, this is
+    /// a no-op; if output is currently rendering,
+    /// it will render immediately after.
+    fn schedule_render(&self) {
+        unsafe { wlc_output_schedule_render(self.0) };
+    }
+
     /// Gets the name of the WlcOutput.
     ///
     /// Names are usually assigned in the format WLC-n,
     /// where the first output is WLC-1.
-    pub fn get_name(&self) -> String {
+    fn get_name(&self) -> String {
         let name: *const i8;
         unsafe {
             name = wlc_output_get_name(self.0);
@@ -243,17 +502,17 @@ impl WlcOutput {
     ///
     /// Returns `true` if the monitor is sleeping,
     /// such as having been set with `set_sleep`.
-    pub fn get_sleep(&self) -> bool {
+    fn get_sleep(&self) -> bool {
         unsafe { wlc_output_get_sleep(self.0) }
     }
 
     /// Sets the sleep status of the output.
-    pub fn set_sleep(&self, sleep: bool) {
+    fn set_sleep(&self, sleep: bool) {
         unsafe { wlc_output_set_sleep(self.0, sleep); }
     }
 
     /// Gets the output resolution in pixels.
-    pub fn get_resolution(&self) -> &Size {
+    fn get_resolution(&self) -> &Size {
         unsafe { &*wlc_output_get_resolution(self.0) }
     }
 
@@ -261,7 +520,7 @@ impl WlcOutput {
     ///
     /// # Safety
     /// This method will crash the program if use when wlc is not running.
-    pub fn set_resolution(&self, size: Size) {
+    fn set_resolution(&self, size: Size) {
         unsafe { wlc_output_set_resolution(self.0, &size); }
     }
 
@@ -271,7 +530,7 @@ impl WlcOutput {
     /// For example tiling wms, may want to use this to keep their tiling order separated
     /// from floating order.
     /// This handles `wlc_output_get_views` and `wlc_output_get_mutable_views`.
-    pub fn get_views(&self) -> Vec<WlcView> {
+    fn get_views(&self) -> Vec<WlcView> {
         unsafe {
             let mut out_memb: libc::size_t = 0;
             let views = wlc_output_get_views(self.0, &mut out_memb);
@@ -288,18 +547,18 @@ impl WlcOutput {
     }
 
     /// Gets the mask of this output
-    pub fn get_mask(&self) -> u32 {
+    fn get_mask(&self) -> u32 {
         unsafe { wlc_output_get_mask(self.0) }
     }
 
     /// Sets the mask for this output
-    pub fn set_mask(&self, mask: u32) {
+    fn set_mask(&self, mask: u32) {
         unsafe { wlc_output_set_mask(self.0, mask) }
     }
 
     /// # Deprecated
     /// This function is equivalent to simply calling get_views
-    pub fn get_mutable_views(&self) -> Vec<WlcView> {
+    fn get_mutable_views(&self) -> Vec<WlcView> {
         self.get_views()
     }
 
@@ -307,7 +566,7 @@ impl WlcOutput {
     ///
     /// Returns success if operation succeeded. An error will be returned
     /// if something went wrong or if wlc isn't running.
-    pub fn set_views(&self, views: &mut Vec<&WlcView>) -> Result<(), &'static str> {
+    fn set_views(&self, views: &mut Vec<&WlcView>) -> Result<(), &'static str> {
             let view_len = views.len() as libc::size_t;
             let view_vals: Vec<uintptr_t> = views.into_iter().map(|v| v.0).collect();
             let const_views = view_vals.as_ptr();
@@ -318,32 +577,9 @@ impl WlcOutput {
             }
         }
     }
-
-    /// Focuses compositor on a specific output.
-    ///
-    /// Pass in Option::None for no focus.
-    pub fn focus(output: Option<&WlcOutput>) {
-        unsafe {
-            match output {
-                Some(output) => wlc_output_focus(output.0),
-                None => wlc_output_focus(0)
-            }
-        }
-    }
 }
 
 impl WlcView {
-
-    /// Compatability/debugging function.
-    ///
-    /// wlc internally stores views and outputs under the same type.
-    /// If for some reason a conversion between the two was required,
-    /// this function could be called. If this is the case please submit
-    /// a bug report.
-    pub fn as_output(self) -> WlcOutput {
-        WlcOutput::from(self)
-    }
-
     /// Create a dummy WlcView for testing purposes.
     ///
     /// # Unsafety
@@ -372,6 +608,7 @@ impl WlcView {
     /// assert!(view < view2);
     /// assert!(view != view2);
     /// ```
+
     pub fn dummy(code: u32) -> WlcView {
         WlcView(code as uintptr_t)
     }
@@ -380,7 +617,7 @@ impl WlcView {
     ///
     /// # Example
     /// ```
-    /// # use rustwlc::WlcView;
+    /// # use rustwlc::{WlcView, WlcViewable};
     /// let view = WlcView::root();
     /// assert!(view.is_root());
     /// ```
@@ -388,17 +625,31 @@ impl WlcView {
         WlcView(0)
     }
 
+}
+
+impl WlcViewable for WlcView {
+
+    /// Compatability/debugging function.
+    ///
+    /// wlc internally stores views and outputs under the same type.
+    /// If for some reason a conversion between the two was required,
+    /// this function could be called. If this is the case please submit
+    /// a bug report.
+    fn as_output(self) -> WlcOutput {
+        WlcOutput::from(self)
+    }
+
     /// Whether this view is the root window (desktop background).
     ///
     /// # Example
     /// ```rust
-    /// # use rustwlc::WlcView;
+    /// # use rustwlc::{WlcView, WlcViewable};
     /// # // This example can be run because WlcView::root() does not interact with wlc
     /// let view = WlcView::root();
     /// assert!(view.is_root());
     /// ```
     #[inline]
-    pub fn is_root(&self) -> bool {
+    fn is_root(&self) -> bool {
         self.0 == 0
     }
 
@@ -409,13 +660,13 @@ impl WlcView {
     ///
     /// # Example
     /// ```rust
-    /// # use rustwlc::WlcView;
+    /// # use rustwlc::{WlcView, WlcViewable};
     /// let view = WlcView::root();
     /// assert!(view.is_root());
     /// assert!(!view.is_window());
     /// ```
     #[inline]
-    pub fn is_window(&self) -> bool {
+    fn is_window(&self) -> bool {
         self.0 != 0
     }
 
@@ -430,7 +681,7 @@ impl WlcView {
     /// such, usage of these functions requires an understanding of
     /// what data they will have. Please review wlc's usage of these
     /// functions before attempting to use them yourself.
-    pub unsafe fn get_user_data<T>(&self) -> &mut T {
+    unsafe fn get_user_data<T>(&self) -> &mut T {
         let raw_data = wlc_handle_get_user_data(self.0);
         return &mut *(raw_data as *mut T);
     }
@@ -446,7 +697,7 @@ impl WlcView {
     /// such, usage of these functions requires an understanding of
     /// what data they will have. Please review wlc's usage of these
     /// functions before attempting to use them yourself.
-    pub unsafe fn set_user_data<T>(&self, data: &T) {
+    unsafe fn set_user_data<T>(&self, data: &T) {
         let data_ptr: *const c_void = data as *const _ as *const c_void;
         wlc_handle_set_user_data(self.0, data_ptr);
     }
@@ -457,65 +708,65 @@ impl WlcView {
     ///
     /// # Behavior
     /// This function will not do anything if `view.is_root()`.
-    pub fn close(&self) {
+    fn close(&self) {
         if self.is_root() { return };
         unsafe { wlc_view_close(self.0); }
     }
 
     /// Gets the WlcOutput this view is currently part of.
-    pub fn get_output(&self) -> WlcOutput {
+    fn get_output(&self) -> WlcOutput {
         unsafe { WlcOutput(wlc_view_get_output(self.0)) }
     }
 
     /// Sets the output that the view renders on.
     ///
     /// This may not be supported by wlc at this time.
-    pub fn set_output(&self, output: &WlcOutput) {
+    fn set_output(&self, output: &WlcOutput) {
         unsafe { wlc_view_set_output(self.0, output.0) }
     }
 
     /// Brings this view to focus.
     ///
     /// Can be called on `WlcView::root()` to lose all focus.
-    pub fn focus(&self) {
+    fn focus(&self) {
         unsafe { wlc_view_focus(self.0); }
     }
 
     /// Sends the view to the back of the compositor
-    pub fn send_to_back(&self) {
+    fn send_to_back(&self) {
         unsafe { wlc_view_send_to_back(self.0); }
     }
 
     /// Sends this view underneath another.
-    pub fn send_below(&self, other: &WlcView) {
+    fn send_below(&self, other: &WlcView) {
         unsafe { wlc_view_send_below(self.0, other.0); }
     }
 
     /// Brings this view above another.
-    pub fn bring_above(&self, other: &WlcView) {
+    fn bring_above(&self, other: &WlcView) {
         unsafe { wlc_view_bring_above(self.0, other.0); }
     }
 
     /// Brings this view to the front of the stack
     /// within its WlcOutput.
-    pub fn bring_to_front(&self) {
+    fn bring_to_front(&self) {
         unsafe { wlc_view_bring_to_front(self.0); }
     }
 
     // TODO Get masks enum working properly
     /// Gets the current visibilty bitmask for the view.
-    pub fn get_mask(&self) -> u32 {
+    fn get_mask(&self) -> u32 {
         unsafe { wlc_view_get_mask(self.0) }
     }
 
     // TODO Get masks enum working properly
     /// Sets the visibilty bitmask for the view.
-    pub fn set_mask(&self, mask: u32) {
+    fn set_mask(&self, mask: u32) {
         unsafe { wlc_view_set_mask(self.0, mask); }
     }
 
     /// Gets the geometry of the view.
-    pub fn get_geometry(&self) -> Option<&Geometry> {
+    fn get_geometry(&self) -> Option<&Geometry> {
         unsafe {
             let geometry = wlc_view_get_geometry(self.0);
             if geometry.is_null() {
@@ -527,7 +778,7 @@ impl WlcView {
     }
 
     /// Gets the geometry of the view (that wlc displays).
-    pub fn get_visible_geometry(&self) -> Geometry {
+    fn get_visible_geometry(&self) -> Geometry {
         let mut geo = Geometry { origin: Point { x: 0, y: 0}, size: Size { w: 0, h: 0 }};
         unsafe {
             wlc_view_get_visible_geometry(self.0, &mut geo);
@@ -538,45 +789,45 @@ impl WlcView {
     /// Sets the geometry of the view.
     ///
     /// Set edges if geometry is caused by interactive resize.
-    pub fn set_geometry(&self, edges: ResizeEdge, geometry: &Geometry) {
+    fn set_geometry(&self, edges: ResizeEdge, geometry: &Geometry) {
         unsafe { wlc_view_set_geometry(self.0, edges.bits(), geometry as *const Geometry); }
     }
 
     /// Gets the type bitfield of the curent view
-    pub fn get_type(&self) -> ViewType {
+    fn get_type(&self) -> ViewType {
         unsafe { wlc_view_get_type(self.0) }
     }
 
     /// Set flag in the type field. Toggle indicates whether it is set.
-    pub fn set_type(&self, view_type: ViewType, toggle: bool) {
+    fn set_type(&self, view_type: ViewType, toggle: bool) {
         unsafe { wlc_view_set_type(self.0, view_type, toggle); }
     }
 
     // TODO get bitflags enums
     /// Get the current ViewState bitfield.
-    pub fn get_state(&self) -> ViewState {
+    fn get_state(&self) -> ViewState {
         unsafe { wlc_view_get_state(self.0) }
     }
 
     /// Set ViewState bit. Toggle indicates whether it is set or not.
-    pub fn set_state(&self, state: ViewState, toggle: bool) {
+    fn set_state(&self, state: ViewState, toggle: bool) {
         unsafe { wlc_view_set_state(self.0, state, toggle); }
     }
 
     /// Gets parent view, returns `WlcView::root()` if this view has no parent.
-    pub fn get_parent(&self) -> WlcView {
+    fn get_parent(&self) -> WlcView {
         unsafe { WlcView(wlc_view_get_parent(self.0)) }
     }
 
     /// Set the parent of this view.
     ///
     /// Call with `WlcView::root()` to make its parent the root window.
-    pub fn set_parent(&self, parent: &WlcView) {
+    fn set_parent(&self, parent: &WlcView) {
         unsafe { wlc_view_set_parent(self.0, parent.0); }
     }
 
     /// Get the title of the view
-    pub fn get_title(&self) -> String {
+    fn get_title(&self) -> String {
         let chars: *const i8;
         unsafe {
             chars = wlc_view_get_title(self.0);
@@ -589,7 +840,7 @@ impl WlcView {
     }
 
     /// Get class (shell surface only).
-    pub fn get_class(&self) -> String {
+    fn get_class(&self) -> String {
         let chars: *const i8;
         unsafe {
             chars = wlc_view_get_class(self.0);
@@ -602,7 +853,7 @@ impl WlcView {
     }
 
     /// Get app id (xdg-surface only).
-    pub fn get_app_id(&self) -> String {
+    fn get_app_id(&self) -> String {
         let chars: *const i8;
         unsafe {
             chars = wlc_view_get_app_id(self.0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,8 @@
 //! extern crate rustwlc;
 //! use rustwlc::callback;
 //! // VIEW_ACTIVATED is a bitflags enum variant, and those must be imported
-//! // manually, or using a wildcatd.
-//! use rustwlc::{WlcView, VIEW_ACTIVATED};
+//! // manually, or using a wildcard.
+//! use rustwlc::{WlcView, WlcViewable, VIEW_ACTIVATED};
 //!
 //! // Callbacks must be labeled extern as they will be called from C
 //! extern "C" fn view_created(view: WlcView) -> bool {
@@ -73,7 +73,7 @@ pub mod wayland;
 pub mod xkb;
 
 pub use types::*;
-pub use handle::{WlcOutput, WlcView};
+pub use handle::{WlcOutput, WlcOutputable, WlcView, WlcViewable};
 
 // Log Handler hack
 static mut rust_logging_fn: fn(_type: LogType, string: &str) = default_log_callback;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //! use rustwlc::callback;
 //! // VIEW_ACTIVATED is a bitflags enum variant, and those must be imported
 //! // manually, or using a wildcard.
-//! use rustwlc::{WlcView, WlcViewable, VIEW_ACTIVATED};
+//! use rustwlc::{WlcView, View, VIEW_ACTIVATED};
 //!
 //! // Callbacks must be labeled extern as they will be called from C
 //! extern "C" fn view_created(view: WlcView) -> bool {
@@ -73,7 +73,7 @@ pub mod wayland;
 pub mod xkb;
 
 pub use types::*;
-pub use handle::{WlcOutput, WlcOutputable, WlcView, WlcViewable};
+pub use handle::{WlcOutput, Output, WlcView, View};
 
 // Log Handler hack
 static mut rust_logging_fn: fn(_type: LogType, string: &str) = default_log_callback;


### PR DESCRIPTION
Added traits to `WlcView` (`WlcViewable`) and `WlcOutput` (`WlcOutputable`). This allows other applications to make test harnesses by making fake handles for test suites.

This should bump us to `0.5`, so please add the appropriate tags and update the crate when you can Snirk.
