### PR TITLE
Fix README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Requires [wlc](https:://github.com/Cloudef/wlc) v0.0.2.
 // For more functional example see example/src/main.rs
 
 extern crate rustwlc;
+use rustwlc::types::*;
 use rustwlc::callback;
 use rustwlc::WlcView;
 


### PR DESCRIPTION
I was not able to compile the example provided in the readme without also including the `rustwlc::types` module.
