### PR TITLE
derive Copy, prefer by-copy parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Snirk Immington <snirk.immington@gmail.com>", "Timidger <apragmaticp
 
 [dependencies]
 libc = "0.2.*"
-bitflags = "0.6.*"
+bitflags = "0.7.*"
 
 [dev-dependencies]
-lazy_static = "0.1.*"
+lazy_static = "0.2.*"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -110,7 +110,7 @@ fn render_output(output: &WlcOutput) {
     let w = resolution.w / 2;
     let h = resolution.h / cmp::max((views.len() + 1) / 2, 1) as u32;
     for (i, view) in views.iter().enumerate() {
-        view.set_geometry(ResizeEdge::empty(), &Geometry {
+        view.set_geometry(ResizeEdge::empty(), Geometry {
             origin: Point { x: if toggle { w as i32 } else { 0 }, y: y },
             size: Size { w: if !toggle && i == views.len() - 1 { resolution.w } else { w }, h: h }
         });
@@ -154,7 +154,7 @@ extern fn on_view_request_resize(view: WlcView, edges: ResizeEdge, origin: &Poin
 
 extern fn on_keyboard_key(view: WlcView, _time: u32, mods: &KeyboardModifiers, key: u32, state: KeyState) -> bool {
     use std::process::Command;
-    let sym = input::keyboard::get_keysym_for_key(key, &mods.mods);
+    let sym = input::keyboard::get_keysym_for_key(key, mods.mods);
     if state == KeyState::Pressed {
         if mods.mods == MOD_CTRL {
             // Key Q
@@ -265,12 +265,12 @@ extern fn on_pointer_motion(_in_view: WlcView, _time: u32, point: &Point) -> boo
                         geo.size.h = new_geo.size.h;
                     }
 
-                    view.set_geometry(comp.edges, &geo);
+                    view.set_geometry(comp.edges, geo);
                 }
                 else {
                     geo.origin.x += dx;
                     geo.origin.y += dy;
-                    view.set_geometry(ResizeEdge::empty(), &geo);
+                    view.set_geometry(ResizeEdge::empty(), geo);
                 }
         }
     }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -29,8 +29,8 @@ fn start_interactive_action(view: WlcView, origin: Point) -> bool {
         if comp.view != None {
             return false;
         }
-        comp.grab = origin.clone();
-        comp.view = Some(view.clone());
+        comp.grab = origin;
+        comp.view = Some(view);
     }
 
     view.bring_to_front();
@@ -55,7 +55,7 @@ fn start_interactive_resize(view: WlcView, edges: ResizeEdge, origin: Point) {
 
     {
         let mut comp = COMPOSITOR.write().unwrap();
-        comp.edges = edges.clone();
+        comp.edges = edges;
         if comp.edges.bits() == 0 {
             let flag_x = if origin.x < halfw {
                 RESIZE_LEFT
@@ -88,7 +88,7 @@ fn stop_interactive_action() {
             view.set_state(VIEW_RESIZING, false)
     }
 
-    (*comp).view = None;
+    comp.view = None;
     comp.edges = ResizeEdge::empty();
 }
 
@@ -96,7 +96,7 @@ fn get_topmost_view(output: WlcOutput, offset: usize) -> Option<WlcView> {
     let views = output.get_views();
     if views.is_empty() { None }
     else {
-        Some(views[(views.len() - 1 + offset) % views.len()].clone())
+        Some(views[(views.len() - 1 + offset) % views.len()])
     }
 }
 
@@ -114,8 +114,8 @@ fn render_output(output: WlcOutput) {
             origin: Point { x: if toggle { w as i32 } else { 0 }, y: y },
             size: Size { w: if !toggle && i == views.len() - 1 { resolution.w } else { w }, h: h }
         });
-        toggle = ! toggle;
-        y = if y > 0 || !toggle { h as i32 } else { 0 };
+        y += if toggle { h as i32 } else { 0 };
+        toggle ^= true;
     }
 }
 
@@ -218,10 +218,10 @@ extern fn on_pointer_motion(_in_view: WlcView, _time: u32, point: &Point) -> boo
         if let Some(ref view) = comp.view {
                 let dx = point.x - comp.grab.x;
                 let dy = point.y - comp.grab.y;
-                let mut geo = view.get_geometry().unwrap().clone();
+                let mut geo = view.get_geometry().unwrap();
                 if comp.edges.bits() != 0 {
                     let min = Size { w: 80u32, h: 40u32};
-                    let mut new_geo = geo.clone();
+                    let mut new_geo = geo;
 
                     if comp.edges.contains(RESIZE_LEFT) {
                         if dx < 0 {
@@ -277,7 +277,7 @@ extern fn on_pointer_motion(_in_view: WlcView, _time: u32, point: &Point) -> boo
 
     {
         let mut comp = COMPOSITOR.write().unwrap();
-        comp.grab = point.clone();
+        comp.grab = *point;
         return comp.view.is_some();
     }
 }

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -172,9 +172,9 @@ impl WlcOutput {
     /// such, usage of these functions requires an understanding of
     /// what data they will have. Please review wlc's usage of these
     /// functions before attempting to use them yourself.
-    pub unsafe fn get_user_data<T>(&self) -> &mut T {
+    pub unsafe fn get_user_data<T>(&self) -> Option<&mut T> {
         let raw_data = wlc_handle_get_user_data(self.0);
-        (raw_data as *mut T).as_mut().unwrap()
+        (raw_data as *mut T).as_mut()
     }
 
     /// Sets user-specified data.
@@ -253,8 +253,8 @@ impl WlcOutput {
     }
 
     /// Gets the output resolution in pixels.
-    pub fn get_resolution(self) -> Size {
-        unsafe { *wlc_output_get_resolution(self.0).as_ref().unwrap() }
+    pub fn get_resolution(self) -> Option<Size> {
+        unsafe { wlc_output_get_resolution(self.0).as_ref().map(|&x| x) }
     }
 
     /// Sets the resolution of the output.
@@ -310,11 +310,11 @@ impl WlcOutput {
         let const_views = views.as_ptr() as *const uintptr_t;
 
         unsafe {
-            let res = match wlc_output_set_views(self.0, const_views, view_len) {
-                true => Ok(()),
-                false => Err("Could not set views on output"),
-            };
-            res
+            if wlc_output_set_views(self.0, const_views, view_len) {
+                Ok(())
+            } else {
+                Err("Could not set views on output")
+            }
         }
     }
 
@@ -323,10 +323,7 @@ impl WlcOutput {
     /// Pass in Option::None for no focus.
     pub fn focus(output: Option<WlcOutput>) {
         unsafe {
-            wlc_output_focus(match output {
-                Some(output) => output.0,
-                None => 0
-            })
+            wlc_output_focus(output.map(|out| out.0).unwrap_or(0))
         }
     }
 }
@@ -431,8 +428,8 @@ impl WlcView {
     /// such, usage of these functions requires an understanding of
     /// what data they will have. Please review wlc's usage of these
     /// functions before attempting to use them yourself.
-    pub unsafe fn get_user_data<T>(&self) -> &mut T {
-        (wlc_handle_get_user_data(self.0) as *mut T).as_mut().unwrap()
+    pub unsafe fn get_user_data<T>(&self) -> Option<&mut T> {
+        (wlc_handle_get_user_data(self.0) as *mut T).as_mut()
     }
 
     /// Sets user-specified data.

--- a/src/input.rs
+++ b/src/input.rs
@@ -49,12 +49,12 @@ pub mod keyboard {
     }
 
     /// Gets a keysym given a key and modifiers.
-    pub fn get_keysym_for_key(key: u32, modifiers: &KeyMod) -> Keysym {
-        unsafe { Keysym::from(super::wlc_keyboard_get_keysym_for_key(key, modifiers)) }
+    pub fn get_keysym_for_key(key: u32, modifiers: KeyMod) -> Keysym {
+        unsafe { Keysym::from(super::wlc_keyboard_get_keysym_for_key(key, &modifiers)) }
     }
 
     /// Gets a UTF32 value for a given key and modifiers.
-    pub fn get_utf32_for_key(key: u32, modifiers: &KeyMod) -> u32 {
-        unsafe { super::wlc_keyboard_get_utf32_for_key(key, modifiers) }
+    pub fn get_utf32_for_key(key: u32, modifiers: KeyMod) -> u32 {
+        unsafe { super::wlc_keyboard_get_utf32_for_key(key, &modifiers) }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,7 +5,7 @@ use std::fmt;
 
 /// Log level to pass into wlc logging
 #[repr(C)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum LogType {
     /// Info log type
     Info,
@@ -19,7 +19,7 @@ pub enum LogType {
 
 /// Type of backend that a window is being composited in
 #[repr(C)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum BackendType {
     /// Backend type is unknown
     None,
@@ -149,7 +149,7 @@ bitflags! {
 
 /// Represents a key state in key events
 #[repr(C)]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum KeyState {
     /// Key is being pressed
     Released = 0,
@@ -159,7 +159,7 @@ pub enum KeyState {
 
 /// Represents a button state in button events
 #[repr(C)]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum ButtonState {
     /// Button is being pressed
     Released = 0,
@@ -169,7 +169,7 @@ pub enum ButtonState {
 
 /// Which axis of the scroll wheel is being used
 #[repr(C)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ScrollAxis {
     /// No axes
     None = 0,
@@ -183,7 +183,7 @@ pub enum ScrollAxis {
 
 /// Touch type in touch interface handler
 #[repr(C)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum TouchType {
     /// Touch down
     Down,
@@ -200,7 +200,7 @@ pub enum TouchType {
 /// State of keyoard modifiers.
 /// i.e. control key, caps lock on
 #[repr(C)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct KeyboardModifiers {
     /// Which "lock" keys are being pressed
     pub leds: KeyboardLed,
@@ -210,7 +210,7 @@ pub struct KeyboardModifiers {
 
 /// Represents the location of a view.
 #[repr(C)]
-#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
 pub struct Point {
     /// x coordinate
     pub x: i32,
@@ -226,7 +226,7 @@ impl fmt::Display for Point {
 
 /// Represents the height and width of a view.
 #[repr(C)]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Size {
     /// Width
     pub w: u32,
@@ -242,7 +242,7 @@ impl fmt::Display for Size {
 
 /// Represents the location and size of a view
 #[repr(C)]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Geometry {
     /// The location of the object
     pub origin: Point,

--- a/src/xkb/mod.rs
+++ b/src/xkb/mod.rs
@@ -89,6 +89,7 @@ pub mod keysyms;
 
 use libc::{c_char, size_t};
 use std::ffi::CString;
+use std::mem;
 // Keysym utils functions
 
 // An xkb keycode.
@@ -124,12 +125,12 @@ use std::ffi::CString;
 /// The name of other unnamed keysyms is the hexadecimal representation of
 /// their value, e.g. "0xabcd1234". Keysym names are case-sensitive.
 ///
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Keysym(u32);
 
 /// Represents flags used for `Keysym::from_name`
 #[repr(C)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum NameFlags {
     /// None, or "Case sensitive"
     None = 0,
@@ -260,8 +261,8 @@ impl Keysym {
     /// ```
     pub fn get_name(&self) -> Option<String> {
         // The xkb documentation specifically recommends 64 as a buffer length
-        let mut buffer_vec: Vec<c_char> = Vec::with_capacity(64);
         unsafe {
+            let mut buffer_vec: [c_char; 64] = mem::uninitialized();
             let buffer: *mut c_char = buffer_vec.as_mut_ptr();
             let length = xkb_keysym_get_name(self.0, buffer, 64);
             match length {
@@ -273,8 +274,8 @@ impl Keysym {
 
     /// Gets the Unicode/UTF8 representation of this keysym.
     pub fn to_utf8(&self) -> Option<String> {
-        let mut buffer_vec: Vec<c_char> = Vec::with_capacity(64);
         unsafe {
+            let mut buffer_vec: [c_char; 64] = mem::uninitialized();
             let buffer: *mut c_char = buffer_vec.as_mut_ptr();
             let result = xkb_keysym_to_utf8(self.0, buffer, 64);
             match result {


### PR DESCRIPTION
Attempts to cover the bullets for `Add Copy trait for Point/Size/Geometry` & `Functions take copyable types instead of references to them`

Also uses std::mem::uninitialized::<[c_char; 64]>() over Vec<c_char>::with_capacity(64) in xkb & bumps crate versions
