### PR TITLE
View properties callback

### DIFF
--- a/src/callback.rs
+++ b/src/callback.rs
@@ -140,7 +140,7 @@ extern "C" {
     //fn wlc_set_input_destroyed_cb(cb: extern "C" fn(&LibinputDevice));
 
     // View properties were updated
-    fn wlc_set_view_properties_updated_cb(view: extern "C" fn(handle: WlcView, mask: u32));
+    fn wlc_set_view_properties_updated_cb(cb: extern "C" fn(handle: WlcView, mask: ViewPropertyType));
 }
 
 /// Callback invoked when an output is created.
@@ -521,8 +521,12 @@ pub fn compositor_terminate(callback: extern "C" fn()) {
     }
 }
 
-/// Callback invoked when a WlcView has its properties updated
-pub fn view_properties_changed(callback: extern "C" fn(handle: WlcView, mask: u32)) {
+/// Callback invoked when a WlcView has its properties updated.
+///
+/// # Arguments
+/// * `view`: View handle that is changing its properties
+/// * `mask`: Bitflag of which property is being updated
+pub fn view_properties_changed(callback: extern "C" fn(handle: WlcView, mask: ViewPropertyType)) {
     unsafe {
         wlc_set_view_properties_updated_cb(callback);
     }

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -138,6 +138,9 @@ extern "C" {
 
     // Input device was destroyed. (Experimental)
     //fn wlc_set_input_destroyed_cb(cb: extern "C" fn(&LibinputDevice));
+
+    // View properties were updated
+    fn wlc_set_view_properties_updated_cb(view: extern "C" fn());
 }
 
 /// Callback invoked when an output is created.
@@ -515,5 +518,12 @@ pub fn compositor_ready(callback: extern "C" fn()) {
 pub fn compositor_terminate(callback: extern "C" fn()) {
     unsafe {
         wlc_set_compositor_terminate_cb(callback);
+    }
+}
+
+/// Callback invoked when a WlcView has its properties updated
+pub fn view_properties_changed(callback: extern "C" fn()) {
+    unsafe {
+        wlc_set_view_properties_updated_cb(callback);
     }
 }

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -140,7 +140,7 @@ extern "C" {
     //fn wlc_set_input_destroyed_cb(cb: extern "C" fn(&LibinputDevice));
 
     // View properties were updated
-    fn wlc_set_view_properties_updated_cb(view: extern "C" fn());
+    fn wlc_set_view_properties_updated_cb(view: extern "C" fn(handle: WlcView, mask: u32));
 }
 
 /// Callback invoked when an output is created.
@@ -522,7 +522,7 @@ pub fn compositor_terminate(callback: extern "C" fn()) {
 }
 
 /// Callback invoked when a WlcView has its properties updated
-pub fn view_properties_changed(callback: extern "C" fn()) {
+pub fn view_properties_changed(callback: extern "C" fn(handle: WlcView, mask: u32)) {
     unsafe {
         wlc_set_view_properties_updated_cb(callback);
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -104,6 +104,19 @@ bitflags! {
 }
 
 bitflags! {
+    /// Which view property is being updated
+    #[repr(C)]
+    pub flags ViewPropertyType: u32 {
+        /// View title is being updated
+        const PROPERTY_TITLE = 0,
+        /// View class is being updated
+        const PROPRETY_CLASS = 1,
+        /// View app id is being updated
+        const PROPERTY_APP_ID = 2,
+    }
+}
+
+bitflags! {
     /// Represents which keyboard meta keys are being pressed.
     #[repr(C)]
     pub flags KeyMod: u32 {


### PR DESCRIPTION
Added `view_properties_updated` callback, which is executed whenever the properties on any view is updated.
