### PR TITLE
Updated debug output for WlcView and WlcOutput

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -130,7 +130,6 @@ extern fn on_view_created(view: WlcView) -> bool {
     view.bring_to_front();
     view.focus();
     render_output(view.get_output());
-    println!("view: {:?}", view);
     true
 }
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -130,6 +130,7 @@ extern fn on_view_created(view: WlcView) -> bool {
     view.bring_to_front();
     view.focus();
     render_output(view.get_output());
+    println!("view: {:?}", view);
     true
 }
 

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -4,7 +4,7 @@
 //! - **Debug**: pointer-prints the underlying `uintptr_t` handle
 //! - **Eq, Ord**: compare the underlying `uintptr_t` handle
 //! - **Clone**: View handles can safely be cloned.
-use std::fmt;
+use std::fmt::{self, Debug};
 
 extern crate libc;
 use libc::{uintptr_t, c_char, c_void};
@@ -32,16 +32,11 @@ pub struct WlcView(uintptr_t);
 
 impl fmt::Debug for WlcView {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut title = self.get_title();
-        let mut class = self.get_class();
-        if title.is_empty() {
-            title = "<no title>".into();
-        }
-        if class.is_empty() {
-            class = "<no class>".into();
-        }
-        write!(f, "WlcView {{ handle: {handle}, title: {title}, class: {class} }}",
-               handle=self.0, title=title, class=class)
+        f.debug_struct("WlcView")
+            .field("handle", &self.0 as &Debug)
+            .field("title", &self.get_title() as &Debug)
+            .field("class", &self.get_class() as &Debug)
+            .finish()
     }
 }
 
@@ -65,9 +60,11 @@ pub struct WlcOutput(uintptr_t);
 
 impl fmt::Debug for WlcOutput {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let name = self.get_name();
-        let views = self.get_views();
-        write!(f, "WlcOutput {{ handle: {handle}, name: {name}, views: {views:?} }}", handle=self.0, name=name, views=views)
+        f.debug_struct("WlcOutput")
+            .field("handle", &self.0 as &Debug)
+            .field("name", &self.get_name() as &Debug)
+            .field("views", &self.get_views() as &Debug)
+            .finish()
     }
 }
 

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -40,7 +40,21 @@ impl fmt::Debug for WlcView {
         if class.is_empty() {
             class = "<no class>".into();
         }
-        write!(f, "WlcView {{ title: {title}, class: {class} }}", title=title, class=class)
+        write!(f, "WlcView {{ handle: {handle}, title: {title}, class: {class} }}",
+               handle=self.0, title=title, class=class)
+    }
+}
+
+impl fmt::Display for WlcView {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut name = self.get_title();
+        if name.is_empty() {
+            name = self.get_class();
+            if name.is_empty() {
+                name = format!("WlcView({handle})", handle=self.0);
+            }
+        }
+        write!(f, "WlcOutput {{ name: {name} }}", name=name)
     }
 }
 
@@ -53,7 +67,14 @@ impl fmt::Debug for WlcOutput {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let name = self.get_name();
         let views = self.get_views();
-        write!(f, "WlcOutput {{ name: {name}, views: {views:?} }}", name=name, views=views)
+        write!(f, "WlcOutput {{ handle: {handle}, name: {name}, views: {views:?} }}", handle=self.0, name=name, views=views)
+    }
+}
+
+impl fmt::Display for WlcOutput {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let name = self.get_name();
+        write!(f, "WlcOutput {{ handle: {handle} name: {name} }}", handle=self.0, name=name)
     }
 }
 

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -4,6 +4,7 @@
 //! - **Debug**: pointer-prints the underlying `uintptr_t` handle
 //! - **Eq, Ord**: compare the underlying `uintptr_t` handle
 //! - **Clone**: View handles can safely be cloned.
+use std::fmt;
 
 extern crate libc;
 use libc::{uintptr_t, c_char, c_void};
@@ -24,15 +25,37 @@ use super::pointer_to_string;
 use super::types::{Geometry, ResizeEdge, Point, Size, ViewType, ViewState};
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// Represents a handle to a wlc view.
 ///
 pub struct WlcView(uintptr_t);
 
+impl fmt::Debug for WlcView {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut title = self.get_title();
+        let mut class = self.get_class();
+        if title.is_empty() {
+            title = "<no title>".into();
+        }
+        if class.is_empty() {
+            class = "<no class>".into();
+        }
+        write!(f, "WlcView {{ title: {title}, class: {class} }}", title=title, class=class)
+    }
+}
+
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// Represents a handle to a wlc output.
 pub struct WlcOutput(uintptr_t);
+
+impl fmt::Debug for WlcOutput {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let name = self.get_name();
+        let views = self.get_views();
+        write!(f, "WlcOutput {{ name: {name}, views: {views:?} }}", name=name, views=views)
+    }
+}
 
 // Applies to both handles
 #[link(name = "wlc")]


### PR DESCRIPTION
Updated debug output  for WlcView/WlcOutput
- `WlcView` lists the title and class names (if available), and the handle number
- `WlcOutput` tells us the name and lists of views associated with it. Also lists handle number

Added display output for WlcView/WlcOutput:
- `WlcView` attempts to list the most descriptive name, falling back to the handle number at worst.
- `WlcOutput` lists the name of the output and the handle.
