### PR TITLE
Fix bindings for input::keyboard

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -29,6 +29,7 @@ fn start_interactive_action(view: WlcView, origin: Point) -> bool {
         return false
     }
     comp.grab = origin;
+    comp.view = Some(view);
 
     view.bring_to_front();
     return true

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -24,17 +24,14 @@ lazy_static! {
 }
 
 fn start_interactive_action(view: WlcView, origin: Point) -> bool {
-    {
-        let mut comp = COMPOSITOR.write().unwrap();
-        if comp.view != None {
-            return false;
-        }
-        comp.grab = origin;
-        comp.view = Some(view);
+    let mut comp = COMPOSITOR.write().unwrap();
+    if comp.view != None {
+        return false
     }
+    comp.grab = origin;
 
     view.bring_to_front();
-    return true;
+    return true
 }
 
 fn start_interactive_move(view: WlcView, origin: Point) {
@@ -154,7 +151,7 @@ extern fn on_view_request_resize(view: WlcView, edges: ResizeEdge, origin: &Poin
 
 extern fn on_keyboard_key(view: WlcView, _time: u32, mods: &KeyboardModifiers, key: u32, state: KeyState) -> bool {
     use std::process::Command;
-    let sym = input::keyboard::get_keysym_for_key(key, mods.mods);
+    let sym = input::keyboard::get_keysym_for_key(key, *mods);
     if state == KeyState::Pressed {
         if mods.mods == MOD_CTRL {
             // Key Q

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,15 +1,18 @@
 //! Contains methods for interacting with the pointer
 //! and keyboard of wlc.
 
-use super::types::{KeyMod, Point};
+use libc::{size_t, uint32_t};
+use super::types::{KeyboardModifiers, Point};
 
 #[link(name = "wlc")]
 extern "C" {
-    //fn wlc_keyboard_get_current_keys(out_memb: *const size_t) -> *const u32;
+    fn wlc_keyboard_get_current_keys(out_memb: *const size_t) -> *const uint32_t;
 
-    fn wlc_keyboard_get_keysym_for_key(key: u32, modifiers: &KeyMod) -> u32;
+    fn wlc_keyboard_get_keysym_for_key(key: uint32_t,
+                                       modifiers: *const KeyboardModifiers) -> uint32_t;
 
-    fn wlc_keyboard_get_utf32_for_key(key: u32, modifiers: &KeyMod) -> u32;
+    fn wlc_keyboard_get_utf32_for_key(key: uint32_t,
+                                      modifiers: *const KeyboardModifiers) -> uint32_t;
 
     // Pointer functions
     fn wlc_pointer_get_position(out_position: *mut Point);
@@ -37,16 +40,28 @@ pub mod pointer {
 }
 
 pub mod keyboard {
-//! Methods for interacting with the keyboard
-    use super::super::types::{KeyMod};
+    //! Methods for interacting with the keyboard
+
+    use std::slice;
+    use libc::size_t;
+    use super::super::types::KeyboardModifiers;
     #[allow(deprecated)]
     use super::super::xkb::Keysym;
 
     /// Get currently held keys.
     /// # Panics
     /// All the time, this function hasn't been implemented yet
-    pub fn get_current_keys<'a>() -> &'a[u32] {
-        unimplemented!();
+    pub fn get_current_keys<'a>() -> Option<&'a[u32]> {
+        let mut size: size_t = 0;
+        unsafe {
+            let out_ptr = super::wlc_keyboard_get_current_keys(&mut size);
+            if size == 0 || out_ptr.is_null() {
+                None
+            }
+            else {
+                Some(slice::from_raw_parts(out_ptr, size as usize))
+            }
+        }
     }
 
     /// Gets a keysym given a key and modifiers.
@@ -55,14 +70,14 @@ pub mod keyboard {
     /// deprecated. Please use `Keysym::raw` on the Keysym returned from this
     /// function for now. **In version 0.6 this will return a u32**.
     #[allow(deprecated)]
-    pub fn get_keysym_for_key(key: u32, modifiers: KeyMod) -> Keysym {
+    pub fn get_keysym_for_key(key: u32, modifiers: KeyboardModifiers) -> Keysym {
         unsafe {
-            Keysym::from(super::wlc_keyboard_get_keysym_for_key(key, &modifiers))
+            Keysym::from(super::wlc_keyboard_get_keysym_for_key(key, &modifiers) as u32)
         }
     }
 
     /// Gets a UTF32 value for a given key and modifiers.
-    pub fn get_utf32_for_key(key: u32, modifiers: KeyMod) -> u32 {
+    pub fn get_utf32_for_key(key: u32, modifiers: KeyboardModifiers) -> u32 {
         unsafe { super::wlc_keyboard_get_utf32_for_key(key, &modifiers) }
     }
 }


### PR DESCRIPTION
Turns out they need a `KeyboardModifier`, not a `KeyMod`. Oops. 
