### PR TITLE
Static Linking Feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ keywords = ["wlc", "Wayland", "compositor", "bindings"]
 readme = "README.md"
 license = "MIT"
 authors = ["Snirk Immington <snirk.immington@gmail.com>", "Timidger <apragmaticplace@gmail.com>"]
+build = "build.rs"
 
 [features]
 wlc-wayland = ["wayland-sys"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ build = "build.rs"
 
 [features]
 wlc-wayland = ["wayland-sys"]
+static-wlc = []
 
 [dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustwlc"
 description = "wlc Wayland library bindings for Rust"
-version = "0.5.1"
+version = "0.5.2"
 repository = "https://github.com/Immington-Industries/rust-wlc/"
 keywords = ["wlc", "Wayland", "compositor", "bindings"]
 readme = "README.md"

--- a/build.rs
+++ b/build.rs
@@ -21,21 +21,21 @@ fn main() {
         println!("cargo:rustc-link-lib=dylib=X11");
         println!("cargo:rustc-link-lib=dylib=X11-xcb");
         println!("cargo:rustc-link-lib=dylib=EGL");
-        println!("cargo:rustc-link-search=native=/usr/include"   );
-        println!("cargo:rustc-link-lib=static=chck-atlas"  );
-        println!("cargo:rustc-link-lib=static=chck-pool"   );
-        println!("cargo:rustc-link-lib=static=chck-buffer" );
-        println!("cargo:rustc-link-lib=static=chck-buffer" );
-        println!("cargo:rustc-link-lib=static=chck-dl"     );
-        println!("cargo:rustc-link-lib=static=chck-fs"     );
-        println!("cargo:rustc-link-lib=static=chck-lut"    );
-        println!("cargo:rustc-link-lib=static=chck-pool"   );
-        println!("cargo:rustc-link-lib=static=chck-sjis"   );
-        println!("cargo:rustc-link-lib=static=chck-string" );
-        println!("cargo:rustc-link-lib=static=chck-tqueue" );
+        println!("cargo:rustc-link-search=native=/usr/include");
+        println!("cargo:rustc-link-lib=static=chck-atlas");
+        println!("cargo:rustc-link-lib=static=chck-pool");
+        println!("cargo:rustc-link-lib=static=chck-buffer");
+        println!("cargo:rustc-link-lib=static=chck-buffer");
+        println!("cargo:rustc-link-lib=static=chck-dl");
+        println!("cargo:rustc-link-lib=static=chck-fs");
+        println!("cargo:rustc-link-lib=static=chck-lut");
+        println!("cargo:rustc-link-lib=static=chck-pool");
+        println!("cargo:rustc-link-lib=static=chck-sjis" );
+        println!("cargo:rustc-link-lib=static=chck-string");
+        println!("cargo:rustc-link-lib=static=chck-tqueue");
         println!("cargo:rustc-link-lib=static=chck-unicode");
-        println!("cargo:rustc-link-lib=static=chck-xdg"    );
-        println!("cargo:rustc-link-lib=static=wlc-protos"    );
+        println!("cargo:rustc-link-lib=static=chck-xdg");
+        println!("cargo:rustc-link-lib=static=wlc-protos");
         println!("cargo:include=/home/timidger/include");
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -36,6 +36,5 @@ fn main() {
         println!("cargo:rustc-link-lib=static=chck-unicode");
         println!("cargo:rustc-link-lib=static=chck-xdg");
         println!("cargo:rustc-link-lib=static=wlc-protos");
-        println!("cargo:include=/home/timidger/include");
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-link-search=/usr/local/lib64")
+}

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,22 @@
 fn main() {
-    println!("cargo:rustc-link-search=/usr/local/lib64")
+    println!("cargo:rustc-link-search=/usr/local/lib64");
+    println!("cargo:rustc-link-lib=dylib=wayland-client");
+    println!("cargo:rustc-link-lib=dylib=wayland-server");
+    println!("cargo:rustc-link-lib=dylib=systemd");
+    println!("cargo:rustc-link-lib=dylib=input");
+    println!("cargo:rustc-link-lib=dylib=udev");
+    println!("cargo:rustc-link-lib=dylib=GLESv2");
+    println!("cargo:rustc-link-lib=dylib=drm");
+    println!("cargo:rustc-link-lib=dylib=gbm");
+    println!("cargo:rustc-link-lib=dylib=xcb");
+    println!("cargo:rustc-link-lib=dylib=xcb-composite");
+    println!("cargo:rustc-link-lib=dylib=xcb-ewmh");
+    println!("cargo:rustc-link-lib=dylib=xcb-xkb");
+    println!("cargo:rustc-link-lib=dylib=xcb-image");
+    println!("cargo:rustc-link-lib=dylib=xcb-xfixes");
+    println!("cargo:rustc-link-lib=dylib=pixman-1");
+    println!("cargo:rustc-link-lib=dylib=X11");
+    println!("cargo:rustc-link-lib=dylib=X11-xcb");
+    println!("cargo:rustc-link-lib=dylib=EGL");
+    println!("cargo:rustc-link-search=native=/usr/include")
 }

--- a/build.rs
+++ b/build.rs
@@ -1,22 +1,41 @@
+use std::env;
+
 fn main() {
-    println!("cargo:rustc-link-search=/usr/local/lib64");
-    println!("cargo:rustc-link-lib=dylib=wayland-client");
-    println!("cargo:rustc-link-lib=dylib=wayland-server");
-    println!("cargo:rustc-link-lib=dylib=systemd");
-    println!("cargo:rustc-link-lib=dylib=input");
-    println!("cargo:rustc-link-lib=dylib=udev");
-    println!("cargo:rustc-link-lib=dylib=GLESv2");
-    println!("cargo:rustc-link-lib=dylib=drm");
-    println!("cargo:rustc-link-lib=dylib=gbm");
-    println!("cargo:rustc-link-lib=dylib=xcb");
-    println!("cargo:rustc-link-lib=dylib=xcb-composite");
-    println!("cargo:rustc-link-lib=dylib=xcb-ewmh");
-    println!("cargo:rustc-link-lib=dylib=xcb-xkb");
-    println!("cargo:rustc-link-lib=dylib=xcb-image");
-    println!("cargo:rustc-link-lib=dylib=xcb-xfixes");
-    println!("cargo:rustc-link-lib=dylib=pixman-1");
-    println!("cargo:rustc-link-lib=dylib=X11");
-    println!("cargo:rustc-link-lib=dylib=X11-xcb");
-    println!("cargo:rustc-link-lib=dylib=EGL");
-    println!("cargo:rustc-link-search=native=/usr/include")
+    if env::var("CARGO_FEATURE_STATIC_WLC").is_ok() {
+        println!("cargo:rustc-link-search=/usr/local/lib64");
+        println!("cargo:rustc-link-lib=dylib=wayland-client");
+        println!("cargo:rustc-link-lib=dylib=wayland-server");
+        println!("cargo:rustc-link-lib=dylib=systemd");
+        println!("cargo:rustc-link-lib=dylib=input");
+        println!("cargo:rustc-link-lib=dylib=udev");
+        println!("cargo:rustc-link-lib=dylib=GLESv2");
+        println!("cargo:rustc-link-lib=dylib=drm");
+        println!("cargo:rustc-link-lib=dylib=gbm");
+        println!("cargo:rustc-link-lib=dylib=xcb");
+        println!("cargo:rustc-link-lib=dylib=xcb-composite");
+        println!("cargo:rustc-link-lib=dylib=xcb-ewmh");
+        println!("cargo:rustc-link-lib=dylib=xcb-xkb");
+        println!("cargo:rustc-link-lib=dylib=xcb-image");
+        println!("cargo:rustc-link-lib=dylib=xcb-xfixes");
+        println!("cargo:rustc-link-lib=dylib=pixman-1");
+        println!("cargo:rustc-link-lib=dylib=X11");
+        println!("cargo:rustc-link-lib=dylib=X11-xcb");
+        println!("cargo:rustc-link-lib=dylib=EGL");
+        println!("cargo:rustc-link-search=native=/usr/include"   );
+        println!("cargo:rustc-link-lib=static=chck-atlas"  );
+        println!("cargo:rustc-link-lib=static=chck-pool"   );
+        println!("cargo:rustc-link-lib=static=chck-buffer" );
+        println!("cargo:rustc-link-lib=static=chck-buffer" );
+        println!("cargo:rustc-link-lib=static=chck-dl"     );
+        println!("cargo:rustc-link-lib=static=chck-fs"     );
+        println!("cargo:rustc-link-lib=static=chck-lut"    );
+        println!("cargo:rustc-link-lib=static=chck-pool"   );
+        println!("cargo:rustc-link-lib=static=chck-sjis"   );
+        println!("cargo:rustc-link-lib=static=chck-string" );
+        println!("cargo:rustc-link-lib=static=chck-tqueue" );
+        println!("cargo:rustc-link-lib=static=chck-unicode");
+        println!("cargo:rustc-link-lib=static=chck-xdg"    );
+        println!("cargo:rustc-link-lib=static=wlc-protos"    );
+        println!("cargo:include=/home/timidger/include");
+    }
 }

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -32,7 +32,8 @@
 use super::types::*;
 use super::handle::{WlcOutput, WlcView};
 
-#[link(name = "wlc", kind="static")]
+#[cfg_attr(feature = "static-wlc", link(name = "wlc", kind = "static"))]
+#[cfg_attr(not(feature = "static-wlc"), link(name = "wlc"))]
 extern "C" {
     // Output was created. Return false if you want to destroy the output.
     // (e.g. failed to allocate data related to view)

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -32,7 +32,7 @@
 use super::types::*;
 use super::handle::{WlcOutput, WlcView};
 
-#[link(name = "wlc")]
+#[link(name = "wlc", kind="static")]
 extern "C" {
     // Output was created. Return false if you want to destroy the output.
     // (e.g. failed to allocate data related to view)

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -72,8 +72,8 @@ impl fmt::Display for WlcOutput {
     }
 }
 
-// Applies to both handles
-#[link(name = "wlc", kind="static")]
+#[cfg_attr(feature = "static-wlc", link(name = "wlc", kind = "static"))]
+#[cfg_attr(not(feature = "static-wlc"), link(name = "wlc"))]
 extern "C" {
     fn wlc_get_outputs(memb: *mut libc::size_t) -> *const libc::uintptr_t;
 

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -73,7 +73,7 @@ impl fmt::Display for WlcOutput {
 }
 
 // Applies to both handles
-#[link(name = "wlc")]
+#[link(name = "wlc", kind="static")]
 extern "C" {
     fn wlc_get_outputs(memb: *mut libc::size_t) -> *const libc::uintptr_t;
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -4,7 +4,8 @@
 use libc::{size_t, uint32_t};
 use super::types::{KeyboardModifiers, Point};
 
-#[link(name = "wlc", kind="static")]
+#[cfg_attr(feature = "static-wlc", link(name = "wlc", kind = "static"))]
+#[cfg_attr(not(feature = "static-wlc"), link(name = "wlc"))]
 extern "C" {
     fn wlc_keyboard_get_current_keys(out_memb: *const size_t) -> *const uint32_t;
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -4,7 +4,7 @@
 use libc::{size_t, uint32_t};
 use super::types::{KeyboardModifiers, Point};
 
-#[link(name = "wlc")]
+#[link(name = "wlc", kind="static")]
 extern "C" {
     fn wlc_keyboard_get_current_keys(out_memb: *const size_t) -> *const uint32_t;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub use wayland::WlcResource;
 static mut rust_logging_fn: fn(_type: LogType, string: &str) = default_log_callback;
 
 // External WLC functions
-#[link(name = "wlc")]
+#[link(name = "wlc", kind="static")]
 extern "C" {
     // init2 -> init :(
     fn wlc_init() -> bool;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,9 @@ pub use wayland::WlcResource;
 static mut rust_logging_fn: fn(_type: LogType, string: &str) = default_log_callback;
 
 // External WLC functions
-#[link(name = "wlc", kind="static")]
+
+#[cfg_attr(feature = "static-wlc", link(name = "wlc", kind = "static"))]
+#[cfg_attr(not(feature = "static-wlc"), link(name = "wlc"))]
 extern "C" {
     // init2 -> init :(
     fn wlc_init() -> bool;

--- a/src/wayland.rs
+++ b/src/wayland.rs
@@ -36,7 +36,7 @@ use types::{Size, Geometry, Point};
 pub struct WlcResource(uintptr_t);
 
 /// Functions defined in wlc-wayland.h
-#[link(name = "wlc")]
+#[link(name = "wlc", kind="static")]
 extern "C" {
     fn wlc_get_wl_display() -> *mut wl_display;
     fn wlc_resource_from_wl_surface_resource(resource: *const wl_resource) -> uintptr_t;

--- a/src/wayland.rs
+++ b/src/wayland.rs
@@ -36,7 +36,8 @@ use types::{Size, Geometry, Point};
 pub struct WlcResource(uintptr_t);
 
 /// Functions defined in wlc-wayland.h
-#[link(name = "wlc", kind="static")]
+#[cfg_attr(feature = "static-wlc", link(name = "wlc", kind = "static"))]
+#[cfg_attr(not(feature = "static-wlc"), link(name = "wlc"))]
 extern "C" {
     fn wlc_get_wl_display() -> *mut wl_display;
     fn wlc_resource_from_wl_surface_resource(resource: *const wl_resource) -> uintptr_t;


### PR DESCRIPTION
Added static linking feature (`static-wlc`). Requires `libwlc` statically linked to `libchck` and installed on the compiling machine in order to compile correctly.