### PR TITLE
WLC Render functions

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,7 @@ use std::env;
 
 fn main() {
     if env::var("CARGO_FEATURE_STATIC_WLC").is_ok() {
-        println!("cargo:rustc-link-search=/usr/local/lib64");
+        println!("cargo:rustc-link-search=/usr/local/lib");
         println!("cargo:rustc-link-lib=dylib=wayland-client");
         println!("cargo:rustc-link-lib=dylib=wayland-server");
         println!("cargo:rustc-link-lib=dylib=systemd");

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -20,6 +20,7 @@ use super::wayland::WlcResource;
 
 use super::pointer_to_string;
 use super::types::{Geometry, ResizeEdge, Point, Size, ViewType, ViewState};
+use super::render::{wlc_output_get_renderer, wlc_output_schedule_render, wlc_renderer};
 
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -82,9 +83,6 @@ extern "C" {
     fn wlc_output_get_name(output: uintptr_t) -> *const c_char;
 
     fn wlc_handle_get_user_data(handle: uintptr_t) -> *mut c_void;
-
-    // Defined in wlc-render.h
-    fn wlc_output_schedule_render(output: uintptr_t);
 
     fn wlc_handle_set_user_data(handle: uintptr_t, userdata: *const c_void);
 
@@ -433,6 +431,13 @@ impl WlcOutput {
     pub fn focus(output: Option<WlcOutput>) {
         unsafe {
             wlc_output_focus(output.map(|out| out.0).unwrap_or(0))
+        }
+    }
+
+    /// Gets the renderer in use for this `WlcOutput`
+    pub fn get_render(&self) -> wlc_renderer {
+        unsafe {
+            wlc_output_get_renderer(self.0)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ pub use handle::{WlcOutput, WlcView};
 pub use wayland::WlcResource;
 
 // Log Handler hack
+#[allow(non_upper_case_globals)]
 static mut rust_logging_fn: fn(_type: LogType, string: &str) = default_log_callback;
 
 // External WLC functions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ pub mod input;
 pub mod wayland;
 #[deprecated]
 pub mod xkb;
+pub mod render;
 
 pub use types::*;
 pub use handle::{WlcOutput, WlcView};

--- a/src/render.rs
+++ b/src/render.rs
@@ -8,18 +8,18 @@ use super::types::{Geometry};
 #[cfg_attr(not(feature = "static-wlc"), link(name = "wlc"))]
 
 #[repr(C)]
-enum wlc_pixel_format {
+pub enum wlc_pixel_format {
     WLC_RGBA8888
 }
 
 #[repr(C)]
-enum wlc_renderer {
+pub enum wlc_renderer {
     WLC_RENDERER_GLES2,
     WLC_NO_RENDERER
 }
 
 #[repr(C)]
-enum wlc_surface_format {
+pub enum wlc_surface_format {
     SURFACE_RGB,
     SURFACE_RGBA,
     SURFACE_EGL,
@@ -30,7 +30,7 @@ enum wlc_surface_format {
 
 extern "C" {
     /// Write pixel data with the specific format to output's framebuffer.
-    /// If the geometry is out of bounds, it will be automaticall clamped.
+    /// If the geometry is out of bounds, it will be automatically clamped.
     fn wlc_pixels_write(format: wlc_pixel_format, geometry: *const Geometry, data: *const c_void);
 
     /// Read pixel data from output's framebuffer.
@@ -61,4 +61,33 @@ extern "C" {
     fn wlc_surface_get_textures(surface: uintptr_t,
                                 out_textures: *mut uint32_t,
                                 out_format: *mut wlc_surface_format);
+}
+
+
+/// Write pixel data with the specific format to output's framebuffer.
+/// If the geometry is out of bounds, it will be automatically clamped.
+///
+/// # Unsafety
+/// The data is converted to a *mut c_void and then passed to C to read.
+/// It should be in the format expected by wlc, see the wlc docs.
+pub fn write_pixels<T>(format: wlc_pixel_format, geometry: Geometry, data: &mut T) {
+    unsafe {
+        let data = data as *mut _ as *mut c_void;
+        wlc_pixels_write(format, &geometry as *const Geometry, data);
+    }
+}
+
+/// Reads the pixels at the specified geometry
+pub fn read_pixels(format: wlc_pixel_format, mut geometry: Geometry) -> ([u8; 9], Vec<u8>) {
+    let data_size = (geometry.size.w * geometry.size.h * 4) as usize;
+    // magic response header size
+    let header_size = 9;
+    let mut out_buf: Vec<u8> = Vec::with_capacity(header_size + data_size);
+    unsafe {
+        wlc_pixels_read(format, &mut geometry as *mut _, out_buf.as_mut_ptr() as *mut c_void);
+    }
+    let mut header_response = [0u8; 9];
+    let response: Vec<u8> = out_buf.drain(0..9).collect();
+    header_response.copy_from_slice(response.as_slice());
+    (header_response, out_buf)
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -4,7 +4,8 @@ use libc::{c_void, uint32_t, uintptr_t};
 use std::mem;
 use super::types::{Geometry, Size};
 
-const BITS_PER_PIXEL: u32 = 32;
+/// Number of bits per pixel (RGBA8888)
+pub const BITS_PER_PIXEL: u32 = 32;
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,23 +1,28 @@
 //! Contains definitions for wlc render functions (wlc-render.h)
 
 use libc::{c_void, uint32_t, uintptr_t};
-use super::handle::{WlcOutput};
 use super::types::{Geometry};
 
 #[cfg_attr(feature = "static-wlc", link(name = "wlc", kind = "static"))]
 #[cfg_attr(not(feature = "static-wlc"), link(name = "wlc"))]
 
 #[repr(C)]
+/// Allowed pixel formats
 pub enum wlc_pixel_format {
+    /// RGBA8888 format
     WLC_RGBA8888
 }
 
 #[repr(C)]
+/// Enabled renderers
 pub enum wlc_renderer {
+    /// Render using GLE
     WLC_RENDERER_GLES2,
+    /// Don't render (headless)
     WLC_NO_RENDERER
 }
 
+#[allow(missing_docs)]
 #[repr(C)]
 pub enum wlc_surface_format {
     SURFACE_RGB,
@@ -35,9 +40,12 @@ extern "C" {
 
     fn wlc_pixels_read(format: wlc_pixel_format, geometry: *const Geometry, data: *mut c_void);
 
+    /** Renders surface. */
+    fn wlc_surface_render(surface: uintptr_t, geometry: *const Geometry);
+
     /// Read pixel data from output's framebuffer.
     /// If theif output is currently rendering, it will render immediately after.
-    fn wlc_output_schedule_render(output: WlcOutput);
+    fn wlc_output_schedule_render(output: uintptr_t);
 
     /// Adds frame callbacks of the given surface for the next output frame.
     /// It applies recursively to all subsurfaces.
@@ -46,7 +54,7 @@ extern "C" {
     fn wlc_surface_flush_frame_callbacks(surface: uintptr_t);
 
     /// Returns currently active renderer on the given output
-    fn wlc_output_get_renderers(output: WlcOutput);
+    fn wlc_output_get_renderers(output: uintptr_t);
 
     /// Fills out_textures[] with the textures of a surface. Returns false if surface is invalid.
     /// Array must have at least 3 elements and should be refreshed at each frame.

--- a/src/render.rs
+++ b/src/render.rs
@@ -69,8 +69,9 @@ extern "C" {
 ///
 /// # Unsafety
 /// The data is converted to a *mut c_void and then passed to C to read.
-/// It should be in the format expected by wlc, see the wlc docs.
-pub fn write_pixels<T>(format: wlc_pixel_format, geometry: Geometry, data: &mut T) {
+/// The size of it should be the stride of the geometry * height of the geometry.
+pub fn write_pixels(format: wlc_pixel_format, geometry: Geometry, data: &mut &[u8]) {
+    // TODO Add check to ensure that the data is the correct size (stride * height)
     unsafe {
         let data = data as *mut _ as *mut c_void;
         wlc_pixels_write(format, &geometry as *const Geometry, data);

--- a/src/render.rs
+++ b/src/render.rs
@@ -79,10 +79,6 @@ extern "C" {
 /// The data is converted to a *mut c_void and then passed to C to read.
 /// The size of it should be the stride of the geometry * height of the geometry.
 pub fn write_pixels(format: wlc_pixel_format, geometry: Geometry, data: &mut [u8]) {
-    let Size { w, h } = geometry.size;
-    let stride = calculate_stride(w);
-    //assert_eq!((stride * h) as usize, data.len(),
-    //           "Length of data buffer does not equal stride * height");
     unsafe {
         let data = data as *mut _ as *mut c_void;
         wlc_pixels_write(format, &geometry as *const Geometry, data);
@@ -109,7 +105,7 @@ pub fn read_pixels(format: wlc_pixel_format, mut geometry: Geometry) -> ([u8; 9]
 }
 
 /// Calculates the stride for ARGB32 encoded buffers
-fn calculate_stride(width: u32) -> u32 {
+pub fn calculate_stride(width: u32) -> u32 {
     // function stolen from CAIRO_STRIDE_FOR_WIDTH macro in carioint.h
     // can be found in the most recent version of the cairo source
     let stride_alignment = ::std::mem::size_of::<u32>() as u32;

--- a/src/render.rs
+++ b/src/render.rs
@@ -113,5 +113,5 @@ fn calculate_stride(width: u32) -> u32 {
     // function stolen from CAIRO_STRIDE_FOR_WIDTH macro in carioint.h
     // can be found in the most recent version of the cairo source
     let stride_alignment = ::std::mem::size_of::<u32>() as u32;
-    ((BITS_PER_PIXEL * width + 7 )+ stride_alignment - 1) /  & stride_alignment.overflowing_neg().0
+    ((BITS_PER_PIXEL * width + 7 ) / 8 + (stride_alignment - 1))  & (stride_alignment.overflowing_neg().0)
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -80,8 +80,8 @@ extern "C" {
 pub fn write_pixels(format: wlc_pixel_format, geometry: Geometry, data: &mut [u8]) {
     let Size { w, h } = geometry.size;
     let stride = calculate_stride(w);
-    assert_eq!((stride * h) as usize, data.len(),
-               "Length of data buffer does not equal stride * height");
+    //assert_eq!((stride * h) as usize, data.len(),
+    //           "Length of data buffer does not equal stride * height");
     unsafe {
         let data = data as *mut _ as *mut c_void;
         wlc_pixels_write(format, &geometry as *const Geometry, data);

--- a/src/render.rs
+++ b/src/render.rs
@@ -64,7 +64,7 @@ extern "C" {
 /// # Unsafety
 /// The data is converted to a *mut c_void and then passed to C to read.
 /// The size of it should be the stride of the geometry * height of the geometry.
-pub fn write_pixels(format: wlc_pixel_format, geometry: Geometry, data: &mut &[u8]) {
+pub fn write_pixels(format: wlc_pixel_format, geometry: Geometry, data: &mut [u8]) {
     // TODO Add check to ensure that the data is the correct size (stride * height)
     unsafe {
         let data = data as *mut _ as *mut c_void;

--- a/src/render.rs
+++ b/src/render.rs
@@ -10,6 +10,7 @@ const BITS_PER_PIXEL: u32 = 32;
 #[cfg_attr(not(feature = "static-wlc"), link(name = "wlc"))]
 
 #[repr(C)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 /// Allowed pixel formats
 pub enum wlc_pixel_format {
     /// RGBA8888 format
@@ -17,6 +18,7 @@ pub enum wlc_pixel_format {
 }
 
 #[repr(C)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 /// Enabled renderers
 pub enum wlc_renderer {
     /// Render using GLE
@@ -27,6 +29,7 @@ pub enum wlc_renderer {
 
 #[allow(missing_docs)]
 #[repr(C)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum wlc_surface_format {
     SURFACE_RGB,
     SURFACE_RGBA,

--- a/src/render.rs
+++ b/src/render.rs
@@ -33,16 +33,10 @@ extern "C" {
     /// If the geometry is out of bounds, it will be automatically clamped.
     fn wlc_pixels_write(format: wlc_pixel_format, geometry: *const Geometry, data: *const c_void);
 
+    fn wlc_pixels_read(format: wlc_pixel_format, geometry: *const Geometry, data: *mut c_void);
+
     /// Read pixel data from output's framebuffer.
-    /// If the geometry is out of bounds, it will be automatically clamped.
-    /// Potentially clamped geometry will be stored in out_geometry,
-    /// to indicate width / height of the returned data.
-    fn wlc_pixels_read(format: wlc_pixel_format, geometry: *const Geometry, data: *const c_void);
-
-    fn wlc_surface_render(surface: uintptr_t, geometry: *const Geometry);
-
-    /// Schedules output for rendering next frame. If output was already scheduled this is no-op,
-    /// if output is currently rendering, it will render immediately after.
+    /// If theif output is currently rendering, it will render immediately after.
     fn wlc_output_schedule_render(output: WlcOutput);
 
     /// Adds frame callbacks of the given surface for the next output frame.

--- a/src/render.rs
+++ b/src/render.rs
@@ -110,5 +110,5 @@ fn calculate_stride(width: u32) -> u32 {
     // function stolen from CAIRO_STRIDE_FOR_WIDTH macro in carioint.h
     // can be found in the most recent version of the cairo source
     let stride_alignment = ::std::mem::size_of::<u32>() as u32;
-    ((BITS_PER_PIXEL * width + 7 )+ stride_alignment - 1) /  & stride_alignment.overflowing_neg().0 - 1
+    ((BITS_PER_PIXEL * width + 7 )+ stride_alignment - 1) /  & stride_alignment.overflowing_neg().0
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -6,9 +6,6 @@ use super::types::{Geometry, Size};
 
 const BITS_PER_PIXEL: u32 = 32;
 
-#[cfg_attr(feature = "static-wlc", link(name = "wlc", kind = "static"))]
-#[cfg_attr(not(feature = "static-wlc"), link(name = "wlc"))]
-
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 /// Allowed pixel formats
@@ -39,6 +36,8 @@ pub enum wlc_surface_format {
     SURFACE_Y_XUXV,
 }
 
+#[cfg_attr(feature = "static-wlc", link(name = "wlc", kind = "static"))]
+#[cfg_attr(not(feature = "static-wlc"), link(name = "wlc"))]
 extern "C" {
     /// Write pixel data with the specific format to output's framebuffer.
     /// If the geometry is out of bounds, it will be automatically clamped.

--- a/src/render.rs
+++ b/src/render.rs
@@ -36,31 +36,31 @@ pub enum wlc_surface_format {
 extern "C" {
     /// Write pixel data with the specific format to output's framebuffer.
     /// If the geometry is out of bounds, it will be automatically clamped.
-    fn wlc_pixels_write(format: wlc_pixel_format, geometry: *const Geometry, data: *const c_void);
+    pub fn wlc_pixels_write(format: wlc_pixel_format, geometry: *const Geometry, data: *const c_void);
 
-    fn wlc_pixels_read(format: wlc_pixel_format, geometry: *const Geometry, data: *mut c_void);
+    pub fn wlc_pixels_read(format: wlc_pixel_format, geometry: *const Geometry, data: *mut c_void);
 
     /** Renders surface. */
-    fn wlc_surface_render(surface: uintptr_t, geometry: *const Geometry);
+    pub fn wlc_surface_render(surface: uintptr_t, geometry: *const Geometry);
 
     /// Read pixel data from output's framebuffer.
     /// If theif output is currently rendering, it will render immediately after.
-    fn wlc_output_schedule_render(output: uintptr_t);
+    pub fn wlc_output_schedule_render(output: uintptr_t) -> wlc_renderer;
 
     /// Adds frame callbacks of the given surface for the next output frame.
     /// It applies recursively to all subsurfaces.
     /// Useful when the compositor creates custom animations which require disabling internal rendering,
     /// but still need to update the surface textures (for ex. video players).
-    fn wlc_surface_flush_frame_callbacks(surface: uintptr_t);
+    pub fn wlc_surface_flush_frame_callbacks(surface: uintptr_t);
 
     /// Returns currently active renderer on the given output
-    fn wlc_output_get_renderers(output: uintptr_t);
+    pub fn wlc_output_get_renderer(output: uintptr_t) -> wlc_renderer;
 
     /// Fills out_textures[] with the textures of a surface. Returns false if surface is invalid.
     /// Array must have at least 3 elements and should be refreshed at each frame.
     /// Note that these are not only OpenGL textures but rather render-specific.
     /// For more info what they are check the renderer's source code */
-    fn wlc_surface_get_textures(surface: uintptr_t,
+    pub fn wlc_surface_get_textures(surface: uintptr_t,
                                 out_textures: *mut uint32_t,
                                 out_format: *mut wlc_surface_format);
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,0 +1,64 @@
+//! Contains definitions for wlc render functions (wlc-render.h)
+
+use libc::{c_void, uint32_t, uintptr_t};
+use super::handle::{WlcOutput};
+use super::types::{Geometry};
+
+#[cfg_attr(feature = "static-wlc", link(name = "wlc", kind = "static"))]
+#[cfg_attr(not(feature = "static-wlc"), link(name = "wlc"))]
+
+#[repr(C)]
+enum wlc_pixel_format {
+    WLC_RGBA8888
+}
+
+#[repr(C)]
+enum wlc_renderer {
+    WLC_RENDERER_GLES2,
+    WLC_NO_RENDERER
+}
+
+#[repr(C)]
+enum wlc_surface_format {
+    SURFACE_RGB,
+    SURFACE_RGBA,
+    SURFACE_EGL,
+    SURFACE_Y_UV,
+    SURFACE_Y_U_V,
+    SURFACE_Y_XUXV,
+}
+
+extern "C" {
+    /// Write pixel data with the specific format to output's framebuffer.
+    /// If the geometry is out of bounds, it will be automaticall clamped.
+    fn wlc_pixels_write(format: wlc_pixel_format, geometry: *const Geometry, data: *const c_void);
+
+    /// Read pixel data from output's framebuffer.
+    /// If the geometry is out of bounds, it will be automatically clamped.
+    /// Potentially clamped geometry will be stored in out_geometry,
+    /// to indicate width / height of the returned data.
+    fn wlc_pixels_read(format: wlc_pixel_format, geometry: *const Geometry, data: *const c_void);
+
+    fn wlc_surface_render(surface: uintptr_t, geometry: *const Geometry);
+
+    /// Schedules output for rendering next frame. If output was already scheduled this is no-op,
+    /// if output is currently rendering, it will render immediately after.
+    fn wlc_output_schedule_render(output: WlcOutput);
+
+    /// Adds frame callbacks of the given surface for the next output frame.
+    /// It applies recursively to all subsurfaces.
+    /// Useful when the compositor creates custom animations which require disabling internal rendering,
+    /// but still need to update the surface textures (for ex. video players).
+    fn wlc_surface_flush_frame_callbacks(surface: uintptr_t);
+
+    /// Returns currently active renderer on the given output
+    fn wlc_output_get_renderers(output: WlcOutput);
+
+    /// Fills out_textures[] with the textures of a surface. Returns false if surface is invalid.
+    /// Array must have at least 3 elements and should be refreshed at each frame.
+    /// Note that these are not only OpenGL textures but rather render-specific.
+    /// For more info what they are check the renderer's source code */
+    fn wlc_surface_get_textures(surface: uintptr_t,
+                                out_textures: *mut uint32_t,
+                                out_format: *mut wlc_surface_format);
+}


### PR DESCRIPTION
* Added bindings for all functions defined in `wlc/render.h`
* Wrapped `write_pixels`
  + Includes bounds assert for buffer
* Wrapped `read_pixels`

Fixes #25 