### PR TITLE
Added "dummy" feature to rust-wlc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ build = "build.rs"
 [features]
 wlc-wayland = ["wayland-sys"]
 static-wlc = []
+dummy = []
 
 [dependencies]
 libc = "0.2"

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -30,7 +30,7 @@
 //! ```
 
 use super::types::*;
-use super::handle::{WlcOutput, WlcView};
+use ::{WlcOutput, WlcView};
 
 #[cfg_attr(feature = "static-wlc", link(name = "wlc", kind = "static"))]
 #[cfg_attr(not(feature = "static-wlc"), link(name = "wlc"))]

--- a/src/dummy_callback.rs
+++ b/src/dummy_callback.rs
@@ -1,0 +1,131 @@
+//! Dummy wlc callbacks for events.
+#![allow(missing_docs)]
+
+use super::types::*;
+use ::{WlcOutput, WlcView};
+
+
+pub fn output_created(_callback: extern "C" fn(output: WlcOutput) -> bool) {
+    unimplemented!()
+}
+
+pub fn output_destroyed(_callback: extern "C" fn(output: WlcOutput)) {
+    unimplemented!()
+}
+
+pub fn output_focus(_callback: extern "C" fn(output: WlcOutput, focused: bool)) {
+    unimplemented!()
+}
+
+pub fn output_resolution(_callback: extern "C" fn(output: WlcOutput,
+                                                 old_size: &Size,
+                                                 new_size: &Size)) {
+    unimplemented!()
+}
+
+pub fn output_context_destroyed(_cb: extern "C" fn(output: WlcOutput)) {
+    unimplemented!()
+}
+
+pub fn output_context_created(_cb: extern "C" fn(output: WlcOutput)) {
+    unimplemented!()
+}
+
+pub fn output_render_pre(_callback: extern "C" fn(output: WlcOutput)) {
+    unimplemented!()
+}
+
+pub fn output_render_post(_callback: extern "C" fn(output: WlcOutput)) {
+    unimplemented!()
+}
+
+pub fn view_created(_callback: extern "C" fn(view: WlcView) -> bool) {
+    unimplemented!()
+}
+
+pub fn view_destroyed(_callback: extern "C" fn(view: WlcView)) {
+    unimplemented!()
+}
+
+pub fn view_focus(_callback: extern "C" fn(handle: WlcView, focused: bool)) {
+    unimplemented!()
+}
+
+pub fn view_move_to_output(_callback: extern "C" fn(view: WlcView,
+                                                   old_output: WlcOutput,
+                                                   new_output: WlcOutput)) {
+    unimplemented!()
+}
+
+pub fn view_request_geometry(_callback: extern "C" fn(handle: WlcView,
+                                                     geometry: &Geometry)) {
+    unimplemented!()
+}
+
+pub fn view_request_state(_callback: extern "C" fn(current: WlcView,
+                                                  state: ViewState,
+                                                  handled: bool)) {
+    unimplemented!()
+}
+
+pub fn view_request_move(_callback: extern "C" fn(handle: WlcView,
+                                                 destination: &Point)) {
+    unimplemented!()
+}
+
+pub fn view_request_resize(_callback: extern "C" fn(handle: WlcView,
+                                                   edge: ResizeEdge,
+                                                   location: &Point)) {
+    unimplemented!()
+}
+
+pub fn view_render_pre(_callback: extern "C" fn(view: WlcView)) {
+    unimplemented!()
+}
+
+pub fn view_render_post(_callback: extern "C" fn(view: WlcView)) {
+    unimplemented!()
+}
+
+pub fn keyboard_key(_callback: extern "C" fn(view: WlcView, time: u32,
+                                            mods: &KeyboardModifiers, key: u32,
+                                            state: KeyState) -> bool) {
+    unimplemented!()
+}
+
+pub fn pointer_button(_callback: extern "C" fn(view: WlcView, time: u32,
+                                              mods: &KeyboardModifiers,
+                                              button: u32, state: ButtonState,
+                                              point: &Point) -> bool) {
+    unimplemented!()
+}
+
+pub fn pointer_scroll(_callback: extern "C" fn(view: WlcView, time: u32,
+                                              mods: &KeyboardModifiers,
+                                              axis: ScrollAxis,
+                                              amount: [f64; 2]) -> bool) {
+    unimplemented!()
+}
+
+pub fn pointer_motion(_callback: extern "C" fn(view: WlcView, time: u32,
+                                              point: &Point) -> bool) {
+    unimplemented!()
+}
+
+pub fn touch(_callback: extern "C" fn(handle: WlcView, time: u32,
+                                     mods: &KeyboardModifiers, touch: TouchType,
+                                     slot: i32, point: &Point) -> bool) {
+    unimplemented!()
+}
+
+pub fn compositor_ready(_callback: extern "C" fn()) {
+    unimplemented!()
+}
+
+pub fn compositor_terminate(_callback: extern "C" fn()) {
+    unimplemented!()
+}
+
+pub fn view_properties_changed(_callback: extern "C" fn(handle: WlcView, mask: ViewPropertyType)) {
+    unimplemented!()
+}

--- a/src/dummy_callback.rs
+++ b/src/dummy_callback.rs
@@ -6,126 +6,126 @@ use ::{WlcOutput, WlcView};
 
 
 pub fn output_created(_callback: extern "C" fn(output: WlcOutput) -> bool) {
-    unimplemented!()
+
 }
 
 pub fn output_destroyed(_callback: extern "C" fn(output: WlcOutput)) {
-    unimplemented!()
+
 }
 
 pub fn output_focus(_callback: extern "C" fn(output: WlcOutput, focused: bool)) {
-    unimplemented!()
+
 }
 
 pub fn output_resolution(_callback: extern "C" fn(output: WlcOutput,
                                                  old_size: &Size,
                                                  new_size: &Size)) {
-    unimplemented!()
+
 }
 
 pub fn output_context_destroyed(_cb: extern "C" fn(output: WlcOutput)) {
-    unimplemented!()
+
 }
 
 pub fn output_context_created(_cb: extern "C" fn(output: WlcOutput)) {
-    unimplemented!()
+
 }
 
 pub fn output_render_pre(_callback: extern "C" fn(output: WlcOutput)) {
-    unimplemented!()
+
 }
 
 pub fn output_render_post(_callback: extern "C" fn(output: WlcOutput)) {
-    unimplemented!()
+
 }
 
 pub fn view_created(_callback: extern "C" fn(view: WlcView) -> bool) {
-    unimplemented!()
+
 }
 
 pub fn view_destroyed(_callback: extern "C" fn(view: WlcView)) {
-    unimplemented!()
+
 }
 
 pub fn view_focus(_callback: extern "C" fn(handle: WlcView, focused: bool)) {
-    unimplemented!()
+
 }
 
 pub fn view_move_to_output(_callback: extern "C" fn(view: WlcView,
                                                    old_output: WlcOutput,
                                                    new_output: WlcOutput)) {
-    unimplemented!()
+
 }
 
 pub fn view_request_geometry(_callback: extern "C" fn(handle: WlcView,
                                                      geometry: &Geometry)) {
-    unimplemented!()
+
 }
 
 pub fn view_request_state(_callback: extern "C" fn(current: WlcView,
                                                   state: ViewState,
                                                   handled: bool)) {
-    unimplemented!()
+
 }
 
 pub fn view_request_move(_callback: extern "C" fn(handle: WlcView,
                                                  destination: &Point)) {
-    unimplemented!()
+
 }
 
 pub fn view_request_resize(_callback: extern "C" fn(handle: WlcView,
                                                    edge: ResizeEdge,
                                                    location: &Point)) {
-    unimplemented!()
+
 }
 
 pub fn view_render_pre(_callback: extern "C" fn(view: WlcView)) {
-    unimplemented!()
+
 }
 
 pub fn view_render_post(_callback: extern "C" fn(view: WlcView)) {
-    unimplemented!()
+
 }
 
 pub fn keyboard_key(_callback: extern "C" fn(view: WlcView, time: u32,
                                             mods: &KeyboardModifiers, key: u32,
                                             state: KeyState) -> bool) {
-    unimplemented!()
+
 }
 
 pub fn pointer_button(_callback: extern "C" fn(view: WlcView, time: u32,
                                               mods: &KeyboardModifiers,
                                               button: u32, state: ButtonState,
                                               point: &Point) -> bool) {
-    unimplemented!()
+
 }
 
 pub fn pointer_scroll(_callback: extern "C" fn(view: WlcView, time: u32,
                                               mods: &KeyboardModifiers,
                                               axis: ScrollAxis,
                                               amount: [f64; 2]) -> bool) {
-    unimplemented!()
+
 }
 
 pub fn pointer_motion(_callback: extern "C" fn(view: WlcView, time: u32,
                                               point: &Point) -> bool) {
-    unimplemented!()
+
 }
 
 pub fn touch(_callback: extern "C" fn(handle: WlcView, time: u32,
                                      mods: &KeyboardModifiers, touch: TouchType,
                                      slot: i32, point: &Point) -> bool) {
-    unimplemented!()
+
 }
 
 pub fn compositor_ready(_callback: extern "C" fn()) {
-    unimplemented!()
+
 }
 
 pub fn compositor_terminate(_callback: extern "C" fn()) {
-    unimplemented!()
+
 }
 
 pub fn view_properties_changed(_callback: extern "C" fn(handle: WlcView, mask: ViewPropertyType)) {
-    unimplemented!()
+
 }

--- a/src/dummy_handle.rs
+++ b/src/dummy_handle.rs
@@ -528,13 +528,13 @@ impl WlcView {
     /// Dummy turns a wl_surface into a wlc view.
     ///
     /// Always returns None
-    pub fn view_from_surface(surface: WlcResource,
-                             client: *mut wl_client,
-                             interface: *const wl_interface,
-                             implementation: *const c_void,
-                             version: uint32_t,
-                             id: uint32_t,
-                             userdata: *mut c_void )
+    pub fn view_from_surface(_surface: WlcResource,
+                             _client: *mut wl_client,
+                             _interface: *const wl_interface,
+                             _implementation: *const c_void,
+                             _version: uint32_t,
+                             _id: uint32_t,
+                             _userdata: *mut c_void )
                              -> Option<Self> {
         None
     }

--- a/src/dummy_handle.rs
+++ b/src/dummy_handle.rs
@@ -38,30 +38,6 @@ pub struct WlcView {
     view_state: ViewState,
 }
 
-/*impl fmt::Debug for WlcView {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("WlcView")
-            .field("handle", &self.handle as &Debug)
-            .field("title", &self.get_title() as &Debug)
-            .field("class", &self.get_class() as &Debug)
-            .finish()
-    }
-}
-
-impl fmt::Display for WlcView {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut name = self.get_title();
-        if name.is_empty() {
-            name = self.get_class();
-            if name.is_empty() {
-                name = format!("WlcView({handle})", handle=self.0);
-            }
-        }
-        write!(f, "WlcOutput {{ name: {name} }}", name=name)
-    }
-}
-
-*/
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// Represents a handle to a wlc output.
 pub struct WlcOutput {
@@ -74,31 +50,23 @@ pub struct WlcOutput {
     virtual_resolution: Option<Size>,
     views: Vec<WlcView>
 }
-/*
-
-impl fmt::Debug for WlcOutput {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("WlcOutput")
-            .field("handle", &self.0 as &Debug)
-            .field("name", &self.get_name() as &Debug)
-            .field("views", &self.get_views() as &Debug)
-            .finish()
-    }
-}
-
-impl fmt::Display for WlcOutput {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let name = self.get_name();
-        write!(f, "WlcOutput {{ handle: {handle} name: {name} }}", handle=self.0, name=name)
-    }
-}
-*/
-
 
 #[cfg(feature="wlc-wayland")]
 impl Into<WlcResource> for WlcView {
     fn into(self) -> WlcResource {
         WlcResource::from(self.0)
+    }
+}
+
+impl From<WlcView> for WlcOutput {
+    fn from(view: WlcView) -> Self {
+        WlcOutput::dummy(view.handle)
+    }
+}
+
+impl From<WlcOutput> for WlcView {
+    fn from(output: WlcOutput) -> Self {
+        WlcView::dummy(output.handle)
     }
 }
 
@@ -160,7 +128,7 @@ impl WlcOutput {
     pub unsafe fn dummy(code: u32) -> WlcOutput {
         WlcOutput {
             handle: code as libc::uintptr_t,
-            name: "",
+            name: "".into(),
             sleep: false,
             scaling: 1,
             mask: 0,
@@ -205,8 +173,10 @@ impl WlcOutput {
     }
 
     /// Dummy gets the currently focused output.
+    ///
+    /// Always panics
     pub fn focused() -> WlcOutput {
-        println!("Dummy call to wlc_get_focused_output")
+        unimplemented!()
     }
 
     /// Dummy gets the name of the WlcOutput.
@@ -274,7 +244,7 @@ impl WlcOutput {
     ///
     /// Always succeeds
     pub fn set_views(self, views: &[WlcView]) -> Result<(), &'static str> {
-        Ok(self.views = views.iter().collect())
+        Ok(self.views = views.iter().map(|v| *v).collect())
     }
 
     /// Dummy focuses compositor on a specific output.
@@ -329,9 +299,9 @@ impl WlcView {
     pub unsafe fn dummy(code: u32) -> WlcView {
         WlcView {
             handle: code as uintptr_t,
-            title: "",
-            class: "",
-            app_id: "",
+            title: "".into(),
+            class: "".into(),
+            app_id: "".into(),
             pid: 0 as pid_t,
             output: WlcOutput::dummy(0),
             geometry: Geometry::zero(),

--- a/src/dummy_handle.rs
+++ b/src/dummy_handle.rs
@@ -1,8 +1,5 @@
 //! Contains dummy definitions for wlc handle types.
 
-#[cfg(not(feature = "dummy"))]
-pub use super::dummy_handle::*;
-
 extern crate libc;
 use libc::{uint32_t, pid_t};
 

--- a/src/dummy_handle.rs
+++ b/src/dummy_handle.rs
@@ -1,12 +1,13 @@
 //! Contains dummy definitions for wlc handle types.
 
-use std::fmt::{self, Debug};
-
 #[cfg(not(feature = "dummy"))]
 pub use super::dummy_handle::*;
 
 extern crate libc;
-use libc::{uintptr_t, c_char, c_void, uint32_t, pid_t};
+use libc::{uint32_t, pid_t};
+
+#[cfg(feature="wlc-wayland")]
+use libc::c_void;
 
 #[cfg(feature="wlc-wayland")]
 use wayland_sys::server::{wl_resource, wl_client};
@@ -17,14 +18,13 @@ use wayland_sys::common::wl_interface;
 #[cfg(feature="wlc-wayland")]
 use super::wayland::WlcResource;
 
-use super::pointer_to_string;
-use super::types::{Geometry, ResizeEdge, Point, Size, ViewType, ViewState};
+use super::types::{Geometry, ResizeEdge, Size, ViewType, ViewState};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 /// Represents a handle to a wlc view.
 ///
 pub struct WlcView {
-    handle: libc::uint32_t,
+    handle: uint32_t,
     title: String,
     class: String,
     app_id: String,
@@ -41,7 +41,7 @@ pub struct WlcView {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 /// Represents a handle to a wlc output.
 pub struct WlcOutput {
-    handle: libc::uint32_t,
+    handle: uint32_t,
     name: String,
     sleep: bool,
     scaling: u32,
@@ -49,13 +49,6 @@ pub struct WlcOutput {
     resolution: Option<Size>,
     virtual_resolution: Option<Size>,
     views: Vec<WlcView>
-}
-
-#[cfg(feature="wlc-wayland")]
-impl Into<WlcResource> for WlcView {
-    fn into(self) -> WlcResource {
-        WlcResource::from(self.0)
-    }
 }
 
 impl From<WlcView> for WlcOutput {
@@ -150,7 +143,7 @@ impl WlcOutput {
     /// Dummy sets user-specified data.
     ///
     /// Always panics w/ `unimplemented!`
-    pub unsafe fn set_user_data<T>(&self, data: &T) {
+    pub unsafe fn set_user_data<T>(&self, _data: &T) {
         unimplemented!()
     }
 
@@ -250,7 +243,7 @@ impl WlcOutput {
     /// Dummy focuses compositor on a specific output.
     ///
     /// Does nothing.
-    pub fn focus(output: Option<WlcOutput>) {
+    pub fn focus(_output: Option<WlcOutput>) {
         println!("Dummy call to wlc_output_focus");
     }
 }
@@ -370,7 +363,7 @@ impl WlcView {
     /// Dummy sets user-specified data.
     ///
     /// Always panics w/ `unimplemented!`
-    pub unsafe fn set_user_data<T>(&self, data: &T) {
+    pub unsafe fn set_user_data<T>(&self, _data: &T) {
         unimplemented!()
     }
 
@@ -406,14 +399,14 @@ impl WlcView {
     /// Dummy sends this view underneath another.
     ///
     /// Does nothing
-    pub fn send_below(self, other: WlcView) {
+    pub fn send_below(self, _other: WlcView) {
         println!("Dummy call to wlc_view_send_below")
     }
 
     /// Dummy brings this view above another.
     ///
     /// Does nothing
-    pub fn bring_above(self, other: WlcView) {
+    pub fn bring_above(self, _other: WlcView) {
         println!("Dummy call to wlc_view_bring_above")
     }
 
@@ -450,7 +443,7 @@ impl WlcView {
     /// Dummy sets the geometry of the view.
     ///
     /// Ignores `edges`
-    pub fn set_geometry(&mut self, edges: ResizeEdge, geometry: Geometry) {
+    pub fn set_geometry(&mut self, _edges: ResizeEdge, geometry: Geometry) {
         self.geometry = geometry;
     }
 
@@ -492,7 +485,7 @@ impl WlcView {
     /// Dummy set the parent of this view.
     ///
     /// Will always panic
-    pub fn set_parent(self, parent: &WlcView) {
+    pub fn set_parent(self, _parent: &WlcView) {
         unimplemented!()
     }
 
@@ -523,7 +516,7 @@ impl WlcView {
     /// Always return a null pointer
     #[cfg(feature="wlc-wayland")]
     pub fn get_client(self) -> *mut wl_client {
-        c_void as *mut _
+        ::std::ptr::null_mut() as *mut _
     }
 
     /// Dummy get the wl_role associated with surface that this WLC view refers to.
@@ -531,7 +524,7 @@ impl WlcView {
     /// Always return a null pointer
     #[cfg(feature="wlc-wayland")]
     pub fn get_role(self) -> *mut wl_resource {
-        c_void as *mut _
+        ::std::ptr::null_mut() as *mut _
     }
 
     #[cfg(feature="wlc-wayland")]

--- a/src/dummy_handle.rs
+++ b/src/dummy_handle.rs
@@ -1,0 +1,575 @@
+//! Contains dummy definitions for wlc handle types.
+
+use std::fmt::{self, Debug};
+
+#[cfg(not(feature = "dummy"))]
+pub use super::dummy_handle::*;
+
+extern crate libc;
+use libc::{uintptr_t, c_char, c_void, uint32_t, pid_t};
+
+#[cfg(feature="wlc-wayland")]
+use wayland_sys::server::{wl_resource, wl_client};
+
+#[cfg(feature="wlc-wayland")]
+use wayland_sys::common::wl_interface;
+
+#[cfg(feature="wlc-wayland")]
+use super::wayland::WlcResource;
+
+use super::pointer_to_string;
+use super::types::{Geometry, ResizeEdge, Point, Size, ViewType, ViewState};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// Represents a handle to a wlc view.
+///
+pub struct WlcView {
+    handle: libc::uint32_t,
+    title: String,
+    class: String,
+    app_id: String,
+    pid: pid_t,
+    output: WlcOutput,
+    geometry: Geometry,
+    visible_geometry: Geometry,
+    focus: bool,
+    mask: u32,
+    view_type: ViewType,
+    view_state: ViewState,
+}
+
+/*impl fmt::Debug for WlcView {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("WlcView")
+            .field("handle", &self.handle as &Debug)
+            .field("title", &self.get_title() as &Debug)
+            .field("class", &self.get_class() as &Debug)
+            .finish()
+    }
+}
+
+impl fmt::Display for WlcView {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut name = self.get_title();
+        if name.is_empty() {
+            name = self.get_class();
+            if name.is_empty() {
+                name = format!("WlcView({handle})", handle=self.0);
+            }
+        }
+        write!(f, "WlcOutput {{ name: {name} }}", name=name)
+    }
+}
+
+*/
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// Represents a handle to a wlc output.
+pub struct WlcOutput {
+    handle: libc::uint32_t,
+    name: String,
+    sleep: bool,
+    scaling: u32,
+    mask: u32,
+    resolution: Option<Size>,
+    virtual_resolution: Option<Size>,
+    views: Vec<WlcView>
+}
+/*
+
+impl fmt::Debug for WlcOutput {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("WlcOutput")
+            .field("handle", &self.0 as &Debug)
+            .field("name", &self.get_name() as &Debug)
+            .field("views", &self.get_views() as &Debug)
+            .finish()
+    }
+}
+
+impl fmt::Display for WlcOutput {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let name = self.get_name();
+        write!(f, "WlcOutput {{ handle: {handle} name: {name} }}", handle=self.0, name=name)
+    }
+}
+*/
+
+
+#[cfg(feature="wlc-wayland")]
+impl Into<WlcResource> for WlcView {
+    fn into(self) -> WlcResource {
+        WlcResource::from(self.0)
+    }
+}
+
+// TODO Implement this
+/*
+#[cfg(feature = "wlc-wayland")]
+impl Into<WlcView> for wl_resource {
+fn into(self) -> WlcView {
+unsafe { WlcView(wlc_handle_from_wl_surface_resource(&self)) }
+    }
+}
+ */
+
+
+// TODO Implement this
+/*
+#[cfg(feature="wlc-wayland")]
+impl Into<WlcOutput> for wl_resource {
+fn into(self) -> WlcOutput {
+unsafe { WlcOutput(wlc_handle_from_wl_output_resource(&self)) }
+    }
+}
+ */
+
+impl WlcOutput {
+    /// Compatability/debugging function.
+    ///
+    /// wlc internally stores views and outputs under the same type.
+    /// If for some reason a conversion between the two was required,
+    /// this function could be called. If this is the case please submit
+    /// a bug report.
+    pub fn as_view(self) -> WlcView {
+        WlcView::from(self)
+    }
+
+    /// Create a dummy WlcOutput for testing purposes.
+    ///
+    /// # Unsafety
+    /// The following operations on a dummy WlcOutput will cause crashes:
+    ///
+    /// - `WlcOutput::focused` when wlc is not running
+    /// - `WlcOutput::list` when wlc is not running
+    /// - `WlcOutput::set_resolution` on a dummy output
+    ///
+    /// In addition, `WlcOutput::set_views` will return an error.
+    ///
+    /// All other methods can be used on dummy outputs.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use rustwlc::WlcOutput;
+    /// unsafe {
+    ///     let output = WlcOutput::dummy(0u32);
+    ///     let output2 = WlcOutput::dummy(1u32);
+    ///     assert!(output < output2);
+    ///     assert!(output != output2);
+    /// }
+    /// ```
+    pub unsafe fn dummy(code: u32) -> WlcOutput {
+        WlcOutput {
+            handle: code as libc::uintptr_t,
+            name: "",
+            sleep: false,
+            scaling: 1,
+            mask: 0,
+            resolution: None,
+            virtual_resolution: None,
+            views: Vec::new()
+        }
+    }
+
+    // TODO Implement mocks for user data
+
+    /// Dummy gets user-specified data.
+    ///
+    /// Always returns None
+    pub unsafe fn get_user_data<T>(&self) -> Option<&mut T> {
+        None
+    }
+
+    /// Dummy sets user-specified data.
+    ///
+    /// Always panics w/ `unimplemented!`
+    pub unsafe fn set_user_data<T>(&self, data: &T) {
+        unimplemented!()
+    }
+
+    /// Dummy scheduling for output for rendering next frame.
+    ///
+    /// If the output was already scheduled, this is
+    /// a no-op; if output is currently rendering,
+    /// it will render immediately after.
+    pub fn schedule_render(self) {
+        println!("Dummy call to wlc_output_schedule_render")
+    }
+
+    // TODO Mock this
+
+    /// Dummy gets a list of the current outputs.
+    ///
+    /// Always returns an empty list.
+    pub fn list() -> Vec<WlcOutput> {
+        Vec::new()
+    }
+
+    /// Dummy gets the currently focused output.
+    pub fn focused() -> WlcOutput {
+        println!("Dummy call to wlc_get_focused_output")
+    }
+
+    /// Dummy gets the name of the WlcOutput.
+    pub fn get_name(self) -> String {
+        self.name
+    }
+
+    /// Dummy gets the sleep status of the output.
+    pub fn get_sleep(self) -> bool {
+        self.sleep
+    }
+
+    /// Dummy sets the sleep status of the output.
+    pub fn set_sleep(self, sleep: bool) {
+        self.sleep = sleep
+    }
+
+    /// Dummy gets the output's real resolution. Do not use for coordinate boundary.
+    pub fn get_resolution(self) -> Option<Size> {
+        self.resolution
+    }
+
+    /// Dummy get the virtual resolution. Helpful for getting resolution on high dpi displays.
+    pub fn get_virtual_resolution(self) -> Option<Size> {
+        self.virtual_resolution
+    }
+
+    /// Dummy sets the resolution of the output.
+    pub fn set_resolution(self, size: Size, scaling: u32) {
+        self.scaling = scaling;
+        self.resolution = Some(Size {
+            w: size.w * scaling,
+            h: size.h * scaling
+        })
+    }
+
+    /// Dummy gets the scaling for the output.
+    pub fn get_scale(self) -> u32 {
+        self.scaling
+    }
+
+    /// Dummy get views in stack order.
+    pub fn get_views(self) -> Vec<WlcView> {
+        self.views
+    }
+
+    /// Dummy gets the mask of this output
+    pub fn get_mask(self) -> u32 {
+        self.mask
+    }
+
+    /// Dummy sets the mask for this output
+    pub fn set_mask(self, mask: u32) {
+        self.mask = mask
+    }
+
+    /// # Deprecated
+    /// This function is equivalent to simply calling get_views
+    #[deprecated(since = "0.5.3", note = "please use `get_views`")]
+    pub fn get_mutable_views(self) -> Vec<WlcView> {
+        self.get_views()
+    }
+
+    /// Dummy set the views of a given output.
+    ///
+    /// Always succeeds
+    pub fn set_views(self, views: &[WlcView]) -> Result<(), &'static str> {
+        Ok(self.views = views.iter().collect())
+    }
+
+    /// Dummy focuses compositor on a specific output.
+    ///
+    /// Does nothing.
+    pub fn focus(output: Option<WlcOutput>) {
+        println!("Dummy call to wlc_output_focus");
+    }
+}
+
+impl WlcView {
+    /// Compatability/debugging function.
+    ///
+    /// wlc internally stores views and outputs under the same type.
+    /// If for some reason a conversion between the two was required,
+    /// this function could be called. If this is the case please submit
+    /// a bug report.
+    pub fn as_output(self) -> WlcOutput {
+        WlcOutput::from(self)
+    }
+
+    /// Create a dummy WlcView for testing purposes.
+    ///
+    /// # Unsafety
+    /// The following methods on views may crash the program:
+    ///
+    /// - `WlcView::focus` if wlc is not running
+    /// - `WlcView::send_to_back` if wlc is not running
+    /// - `WlcView::send_below` if wlc is not running
+    /// - `WlcView::bring_above` if wlc is not running
+    /// - `WlcView::bring_to_font` if wlc is not running
+    ///
+    /// All other methods can be used on dummy views.
+    ///
+    /// # Note
+    /// `WlcView::root()` is equivalent to `WlcView::dummy(0)`.
+    ///
+    /// ```rust
+    /// # use rustwlc::WlcView;
+    /// assert!(WlcView::root() == unsafe { WlcView::dummy(0) })
+    /// ```
+    /// # Example
+    /// ```rust
+    /// # use rustwlc::WlcView;
+    /// unsafe {
+    ///     let view = WlcView::dummy(0u32);
+    ///     let view2 = WlcView::dummy(1u32);
+    ///     assert!(view < view2);
+    ///     assert!(view != view2);
+    /// }
+    /// ```
+    pub unsafe fn dummy(code: u32) -> WlcView {
+        WlcView {
+            handle: code as uintptr_t,
+            title: "",
+            class: "",
+            app_id: "",
+            pid: 0 as pid_t,
+            output: WlcOutput::dummy(0),
+            geometry: Geometry::zero(),
+            visible_geometry: Geometry::zero(),
+            focus: false,
+            mask: 0,
+            view_type: ViewType::empty(),
+            view_state: ViewState::empty(),
+        }
+    }
+
+    /// Returns a reference to the root window (desktop background).
+    ///
+    /// # Example
+    /// ```
+    /// # use rustwlc::WlcView;
+    /// let view = WlcView::root();
+    /// assert!(view.is_root());
+    /// ```
+    pub fn root() -> WlcView {
+        WlcView::dummy(0)
+    }
+
+    /// Whether this view is the root window (desktop background).
+    ///
+    /// # Example
+    /// ```rust
+    /// # use rustwlc::WlcView;
+    /// # // This example can be run because WlcView::root() does not interact with wlc
+    /// let view = WlcView::root();
+    /// assert!(view.is_root());
+    /// ```
+    #[inline]
+    pub fn is_root(self) -> bool {
+        self.handle == 0
+    }
+
+    /// Whether this view is not the root window (desktop background).
+    ///
+    /// # Usage
+    /// A convenience method, the opposite of `view.is_root()`.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use rustwlc::WlcView;
+    /// let view = WlcView::root();
+    /// assert!(view.is_root());
+    /// assert!(!view.is_window());
+    /// ```
+    #[inline]
+    pub fn is_window(self) -> bool {
+        self.handle != 0
+    }
+
+    // TODO Mock user data
+
+    /// Dummy gets user-specified data.
+    ///
+    /// Always returns `None`
+    pub unsafe fn get_user_data<T>(&self) -> Option<&mut T> {
+        None
+    }
+
+    /// Dummy sets user-specified data.
+    ///
+    /// Always panics w/ `unimplemented!`
+    pub unsafe fn set_user_data<T>(&self, data: &T) {
+        unimplemented!()
+    }
+
+    /// Dummy closes this view.
+    ///
+    /// Does nothing
+    pub fn close(self) {
+        println!("Dummy call to wlc_view_close")
+    }
+
+    /// Dummy gets the WlcOutput this view is currently part of.
+    pub fn get_output(self) -> WlcOutput {
+        self.output
+    }
+
+    /// Dummy sets the output that the view renders on.
+    pub fn set_output(self, output: WlcOutput) {
+        self.output = output
+    }
+
+    /// Dummy brings this view to focus.
+    pub fn focus(self) {
+        self.focus = true
+    }
+
+    /// Dummy sends the view to the back of the compositor
+    ///
+    /// Does nothing
+    pub fn send_to_back(self) {
+        println!("Dummy call to wlc_view_send_to_back")
+    }
+
+    /// Dummy sends this view underneath another.
+    ///
+    /// Does nothing
+    pub fn send_below(self, other: WlcView) {
+        println!("Dummy call to wlc_view_send_below")
+    }
+
+    /// Dummy brings this view above another.
+    ///
+    /// Does nothing
+    pub fn bring_above(self, other: WlcView) {
+        println!("Dummy call to wlc_view_bring_above")
+    }
+
+    /// Dummy brings this view to the front of the stack
+    /// within its WlcOutput.
+    ///
+    /// Does nothing
+    pub fn bring_to_front(self) {
+        println!("Dummy call to wlc_view_bring_to_front")
+    }
+
+    /// Dummy gets the current visibilty bitmask for the view.
+    pub fn get_mask(self) -> u32 {
+        self.mask
+    }
+
+    /// Dummy sets the visibilty bitmask for the view.
+    pub fn set_mask(self, mask: u32) {
+        self.mask = mask
+    }
+
+    /// Dummy gets the geometry of the view.
+    ///
+    /// Always returns Some
+    pub fn get_geometry(self) -> Option<Geometry> {
+        self.geometry
+    }
+
+    /// Dummy gets the geometry of the view (that wlc displays).
+    pub fn get_visible_geometry(self) -> Geometry {
+        self.visible_geometry
+    }
+
+    /// Dummy sets the geometry of the view.
+    ///
+    /// Ignores `edges`
+    pub fn set_geometry(self, edges: ResizeEdge, geometry: Geometry) {
+        self.geometry = geometry;
+    }
+
+    /// Gets the type bitfield of the curent view
+    pub fn get_type(self) -> ViewType {
+        self.view_type
+    }
+
+    /// Dummy set flag in the type field. Toggle indicates whether it is set.
+    pub fn set_type(self, view_type: ViewType, toggle: bool) {
+        if toggle {
+            self.view_type = self.view_type.insert(view_type)
+        } else {
+            self.view_type = self.view_type.remove(view_type)
+        }
+    }
+
+    /// Dummy get the current ViewState bitfield.
+    pub fn get_state(self) -> ViewState {
+        self.view_state
+    }
+
+    /// Dummy set ViewState bit. Toggle indicates whether it is set or not.
+    pub fn set_state(self, state: ViewState, toggle: bool) {
+        if toggle {
+            self.view_state = self.view_state.insert(state)
+        } else {
+            self.view_state = self.view_state.remove(state)
+        }
+    }
+
+    /// Dummy gets parent view, returns `WlcView::root()` if this view has no parent.
+    pub fn get_parent(self) -> WlcView {
+        self.parent
+    }
+
+    /// Dummy set the parent of this view.
+    pub fn set_parent(self, parent: &WlcView) {
+        self.parent = *parent
+    }
+
+    /// Dummy get the title of the view
+    pub fn get_title(self) -> String {
+        self.title
+    }
+
+    /// Dummy get class (shell surface only).
+    pub fn get_class(self) -> String {
+        self.class
+    }
+
+    /// Dummy get app id (xdg-surface only).
+    pub fn get_app_id(self) -> String {
+        self.app_id
+    }
+
+    /// Get the pid associated with this `WlcView`.
+    pub fn get_pid(self) -> pid_t {
+        self.pid
+    }
+
+    // TODO Mock these functions
+
+    /// Dummy get the wl_client associated with this `WlcView`.
+    ///
+    /// Always return a null pointer
+    #[cfg(feature="wlc-wayland")]
+    pub fn get_client(self) -> *mut wl_client {
+        c_void as *mut _
+    }
+
+    /// Dummy get the wl_role associated with surface that this WLC view refers to.
+    ///
+    /// Always return a null pointer
+    #[cfg(feature="wlc-wayland")]
+    pub fn get_role(self) -> *mut wl_resource {
+        c_void as *mut _
+    }
+
+    #[cfg(feature="wlc-wayland")]
+    /// Dummy turns a wl_surface into a wlc view.
+    ///
+    /// Always returns None
+    pub fn view_from_surface(surface: WlcResource,
+                             client: *mut wl_client,
+                             interface: *const wl_interface,
+                             implementation: *const c_void,
+                             version: uint32_t,
+                             id: uint32_t,
+                             userdata: *mut c_void )
+                             -> Option<Self> {
+        None
+    }
+}

--- a/src/dummy_handle.rs
+++ b/src/dummy_handle.rs
@@ -13,7 +13,7 @@ use wayland_sys::server::{wl_resource, wl_client};
 use wayland_sys::common::wl_interface;
 
 #[cfg(feature="wlc-wayland")]
-use super::wayland::WlcResource;
+use super::dummy_wayland::WlcResource;
 
 use super::types::{Geometry, ResizeEdge, Size, ViewType, ViewState};
 

--- a/src/dummy_input.rs
+++ b/src/dummy_input.rs
@@ -1,0 +1,44 @@
+//! Contains methods for interacting with the pointer
+//! and keyboard of wlc.
+
+#![allow(unused_variables)]
+#![allow(dead_code)]
+#![allow(deprecated)]
+
+pub mod pointer {
+//! Methods for interacting with the mouse
+    use super::super::types::{Point};
+
+    /// Gets the current position of the mouse.
+    pub fn get_position() -> Point {
+        let point = Point { x: 0, y: 0 };
+        return point;
+    }
+
+    /// Sets the current mouse position. Required on mouse move callback.
+    pub fn set_position(point: Point) {
+    }
+}
+
+pub mod keyboard {
+//! Methods for interacting with the keyboard
+    use super::super::types::{KeyboardModifiers};
+    use super::super::xkb::Keysym;
+
+    /// Get currently held keys.
+    /// # Panics
+    /// All the time, this function hasn't been implemented yet
+    pub fn get_current_keys<'a>() -> &'a[u32] {
+        unimplemented!();
+    }
+
+    /// Gets a keysym given a key and modifiers.
+    pub fn get_keysym_for_key(key: u32, modifiers: KeyboardModifiers) -> Keysym {
+        unimplemented!()
+    }
+
+    /// Gets a UTF32 value for a given key and modifiers.
+    pub fn get_utf32_for_key(key: u32, modifiers: KeyboardModifiers) -> u32 {
+        unimplemented!()
+    }
+}

--- a/src/dummy_wayland.rs
+++ b/src/dummy_wayland.rs
@@ -1,0 +1,54 @@
+//! Dummy code for wayland functions
+use wayland_sys::server::{wl_display};
+
+use libc::uintptr_t;
+
+use types::{Size, Geometry};
+
+
+/// ## Requires `wlc-wayland` feature
+///
+/// A wlc resource for Wayland interop
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct WlcResource {
+    handle: uintptr_t,
+    size: Size,
+    subsurface_geometry: Geometry,
+    subsurfaces: Vec<WlcResource>
+}
+
+/// Get the wayland display for the current session.
+///
+/// Always panics.
+pub fn get_display() -> *mut wl_display {
+    unimplemented!()
+}
+
+
+impl WlcResource {
+    /// # Requires `wlc-wayland` feature
+    ///
+    /// Gets the size of this surface
+    pub fn get_surface_size(self) -> Size {
+        self.size
+    }
+
+    /// Gets the inner uintptr_t value that resource uses.
+    pub fn get_raw(self) -> uintptr_t {
+        self.handle
+    }
+
+    /// ## Requires `wlc-wayland` feature
+    ///
+    /// Gets a list of subsurfaces from the given view
+    pub fn get_subsurfaces(self) -> Vec<WlcResource> {
+        self.subsurfaces
+    }
+
+    /// # Requires `wlc-wayland` feature
+    ///
+    /// Gets the subsurface geometry of this WlcResource
+    pub fn get_subsurface_geometry(self) -> Geometry {
+        self.subsurface_geometry
+    }
+}

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -21,12 +21,14 @@ use super::wayland::WlcResource;
 use super::pointer_to_string;
 use super::types::{Geometry, ResizeEdge, Point, Size, ViewType, ViewState};
 
+#[cfg(not(feature = "dummy"))]
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// Represents a handle to a wlc view.
 ///
 pub struct WlcView(uintptr_t);
 
+#[cfg(not(feature = "dummy"))]
 impl fmt::Debug for WlcView {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("WlcView")
@@ -37,6 +39,7 @@ impl fmt::Debug for WlcView {
     }
 }
 
+#[cfg(not(feature = "dummy"))]
 impl fmt::Display for WlcView {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut name = self.get_title();
@@ -50,11 +53,13 @@ impl fmt::Display for WlcView {
     }
 }
 
+#[cfg(not(feature = "dummy"))]
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// Represents a handle to a wlc output.
 pub struct WlcOutput(uintptr_t);
 
+#[cfg(not(feature = "dummy"))]
 impl fmt::Debug for WlcOutput {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("WlcOutput")
@@ -65,6 +70,7 @@ impl fmt::Debug for WlcOutput {
     }
 }
 
+#[cfg(not(feature = "dummy"))]
 impl fmt::Display for WlcOutput {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let name = self.get_name();
@@ -74,6 +80,7 @@ impl fmt::Display for WlcOutput {
 
 #[cfg_attr(feature = "static-wlc", link(name = "wlc", kind = "static"))]
 #[cfg_attr(not(feature = "static-wlc"), link(name = "wlc"))]
+#[cfg(not(feature = "dummy"))]
 extern "C" {
     fn wlc_get_outputs(memb: *mut libc::size_t) -> *const libc::uintptr_t;
 
@@ -188,25 +195,29 @@ extern "C" {
 }
 
 #[cfg(feature="wlc-wayland")]
+#[cfg(not(feature = "dummy"))]
 impl Into<WlcResource> for WlcView {
     fn into(self) -> WlcResource {
         WlcResource::from(unsafe { wlc_view_get_surface(self.0) } )
     }
 }
 
-#[cfg(feature="wlc-wayland")]
+#[cfg(feature = "wlc-wayland")]
+#[cfg(not(feature = "dummy"))]
 impl Into<WlcView> for wl_resource {
     fn into(self) -> WlcView {
         unsafe { WlcView(wlc_handle_from_wl_surface_resource(&self)) }
     }
 }
 
+#[cfg(not(feature = "dummy"))]
 impl From<WlcView> for WlcOutput {
     fn from(view: WlcView) -> Self {
         WlcOutput(view.0)
     }
 }
 
+#[cfg(not(feature = "dummy"))]
 impl From<WlcOutput> for WlcView {
     fn from(output: WlcOutput) -> Self {
         WlcView(output.0)
@@ -214,13 +225,14 @@ impl From<WlcOutput> for WlcView {
 }
 
 #[cfg(feature="wlc-wayland")]
+#[cfg(not(feature = "dummy"))]
 impl Into<WlcOutput> for wl_resource {
     fn into(self) -> WlcOutput {
         unsafe { WlcOutput(wlc_handle_from_wl_output_resource(&self)) }
     }
 }
 
-
+#[cfg(not(feature = "dummy"))]
 impl WlcOutput {
     /// Compatability/debugging function.
     ///
@@ -406,6 +418,7 @@ impl WlcOutput {
 
     /// # Deprecated
     /// This function is equivalent to simply calling get_views
+    #[deprecated(since = "0.5.3", note = "please use `get_views`")]
     pub fn get_mutable_views(self) -> Vec<WlcView> {
         self.get_views()
     }
@@ -437,6 +450,7 @@ impl WlcOutput {
     }
 }
 
+#[cfg(not(feature = "dummy"))]
 impl WlcView {
     /// Compatability/debugging function.
     ///

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -23,14 +23,12 @@ use super::wayland::WlcResource;
 use super::pointer_to_string;
 use super::types::{Geometry, ResizeEdge, Point, Size, ViewType, ViewState};
 
-#[cfg(not(feature = "dummy"))]
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// Represents a handle to a wlc view.
 ///
 pub struct WlcView(uintptr_t);
 
-#[cfg(not(feature = "dummy"))]
 impl fmt::Debug for WlcView {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("WlcView")
@@ -41,7 +39,6 @@ impl fmt::Debug for WlcView {
     }
 }
 
-#[cfg(not(feature = "dummy"))]
 impl fmt::Display for WlcView {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut name = self.get_title();
@@ -55,13 +52,11 @@ impl fmt::Display for WlcView {
     }
 }
 
-#[cfg(not(feature = "dummy"))]
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// Represents a handle to a wlc output.
 pub struct WlcOutput(uintptr_t);
 
-#[cfg(not(feature = "dummy"))]
 impl fmt::Debug for WlcOutput {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("WlcOutput")
@@ -72,7 +67,6 @@ impl fmt::Debug for WlcOutput {
     }
 }
 
-#[cfg(not(feature = "dummy"))]
 impl fmt::Display for WlcOutput {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let name = self.get_name();
@@ -82,7 +76,6 @@ impl fmt::Display for WlcOutput {
 
 #[cfg_attr(feature = "static-wlc", link(name = "wlc", kind = "static"))]
 #[cfg_attr(not(feature = "static-wlc"), link(name = "wlc"))]
-#[cfg(not(feature = "dummy"))]
 extern "C" {
     fn wlc_get_outputs(memb: *mut libc::size_t) -> *const libc::uintptr_t;
 
@@ -197,7 +190,6 @@ extern "C" {
 }
 
 #[cfg(feature="wlc-wayland")]
-#[cfg(not(feature = "dummy"))]
 impl Into<WlcResource> for WlcView {
     fn into(self) -> WlcResource {
         WlcResource::from(unsafe { wlc_view_get_surface(self.0) } )
@@ -205,21 +197,18 @@ impl Into<WlcResource> for WlcView {
 }
 
 #[cfg(feature = "wlc-wayland")]
-#[cfg(not(feature = "dummy"))]
 impl Into<WlcView> for wl_resource {
     fn into(self) -> WlcView {
         unsafe { WlcView(wlc_handle_from_wl_surface_resource(&self)) }
     }
 }
 
-#[cfg(not(feature = "dummy"))]
 impl From<WlcView> for WlcOutput {
     fn from(view: WlcView) -> Self {
         WlcOutput(view.0)
     }
 }
 
-#[cfg(not(feature = "dummy"))]
 impl From<WlcOutput> for WlcView {
     fn from(output: WlcOutput) -> Self {
         WlcView(output.0)
@@ -227,14 +216,12 @@ impl From<WlcOutput> for WlcView {
 }
 
 #[cfg(feature="wlc-wayland")]
-#[cfg(not(feature = "dummy"))]
 impl Into<WlcOutput> for wl_resource {
     fn into(self) -> WlcOutput {
         unsafe { WlcOutput(wlc_handle_from_wl_output_resource(&self)) }
     }
 }
 
-#[cfg(not(feature = "dummy"))]
 impl WlcOutput {
     /// Compatability/debugging function.
     ///
@@ -452,7 +439,6 @@ impl WlcOutput {
     }
 }
 
-#[cfg(not(feature = "dummy"))]
 impl WlcView {
     /// Compatability/debugging function.
     ///

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -6,6 +6,8 @@
 //! - **Clone**: View handles can safely be cloned.
 use std::fmt::{self, Debug};
 
+// TODO Remove all this dummy flag, this should basically not change
+
 extern crate libc;
 use libc::{uintptr_t, c_char, c_void, uint32_t, pid_t};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,7 @@ pub fn init() -> Option<fn() -> ()> {
 /// When wlc went to 0.0.1, they added an argumentless init2
 /// to replace the old init that took a WlcInterface. Now,
 /// init2 has been renamed init and init is removed.
+#[deprecated(since = "0.5.3", note = "please use `init`")]
 pub fn init2() -> Option<fn() -> ()> {
     init()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,7 @@ pub use dummy_handle::{WlcOutput, WlcView};
 pub use wayland::WlcResource;
 
 // Log Handler hack
+#[cfg(not(feature = "dummy"))]
 static mut RUST_LOGGING_FN: fn(_type: LogType, string: &str) = default_log_callback;
 
 // External WLC functions
@@ -253,7 +254,7 @@ pub fn log_set_handler(handler: extern "C" fn(type_: LogType, text: *const libc:
 
 /// Dummy call to wlc_log_set_handler. Does nothing.
 #[cfg(feature = "dummy")]
-pub fn log_set_handler(handler: extern "C" fn(type_: LogType, text: *const libc::c_char)) {
+pub fn log_set_handler(_handler: extern "C" fn(type_: LogType, text: *const libc::c_char)) {
     println!("Dummy call to wlc_log_set_handler")
 }
 
@@ -277,9 +278,9 @@ pub fn log_set_rust_handler(handler: fn(type_: LogType, text: &str)) {
         }
 }
 
-// Dummy call to wlc_log_set_handler w/ custom function. Does nothing.
+/// Dummy call to wlc_log_set_handler w/ custom function. Does nothing.
 #[cfg(feature = "dummy")]
-pub fn log_set_rust_handler(handler: fn(type_: LogType, text: &str)) {
+pub fn log_set_rust_handler(_handler: fn(type_: LogType, text: &str)) {
     println!("Dummy call to wlc_log_set_handler w/ custom handler function")
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,9 @@ pub mod dummy_callback;
 #[cfg(not(feature = "dummy"))]
 pub mod callback;
 pub mod types;
+#[cfg(feature = "dummy")]
+pub mod dummy_input;
+#[cfg(not(feature = "dummy"))]
 pub mod input;
 #[cfg(feature="wlc-wayland")]
 pub mod wayland;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,9 @@ use std::ffi;
 mod dummy_handle;
 #[cfg(not(feature = "dummy"))]
 pub mod handle;
+#[cfg(feature = "dummy")]
+pub mod dummy_callback;
+#[cfg(not(feature = "dummy"))]
 pub mod callback;
 pub mod types;
 pub mod input;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,9 @@ extern crate wayland_sys;
 
 use std::ffi;
 
+#[cfg(feature = "dummy")]
+mod dummy_handle;
+#[cfg(not(feature = "dummy"))]
 pub mod handle;
 pub mod callback;
 pub mod types;
@@ -79,7 +82,10 @@ pub mod wayland;
 pub mod xkb;
 
 pub use types::*;
+#[cfg(not(feature = "dummy"))]
 pub use handle::{WlcOutput, WlcView};
+#[cfg(feature = "dummy")]
+pub use dummy_handle::{WlcOutput, WlcView};
 
 #[cfg(feature="wlc-wayland")]
 pub use wayland::WlcResource;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ pub use handle::{WlcOutput, WlcView};
 pub use wayland::WlcResource;
 
 // Log Handler hack
-static mut rust_logging_fn: fn(_type: LogType, string: &str) = default_log_callback;
+static mut RUST_LOGGING_FN: fn(_type: LogType, string: &str) = default_log_callback;
 
 // External WLC functions
 
@@ -221,11 +221,11 @@ pub fn log_set_handler(handler: extern "C" fn(type_: LogType, text: *const libc:
 pub fn log_set_rust_handler(handler: fn(type_: LogType, text: &str)) {
         // Set global handler function
         unsafe {
-            rust_logging_fn = handler;
+            RUST_LOGGING_FN = handler;
             extern "C" fn c_handler(type_: LogType, text: *const libc::c_char) {
                 unsafe {
                     let string = ffi::CStr::from_ptr(text).to_string_lossy().into_owned();
-                    rust_logging_fn(type_, &string);
+                    RUST_LOGGING_FN(type_, &string);
                 }
             }
             wlc_log_set_handler(c_handler);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,30 +71,49 @@ use std::ffi;
 
 #[cfg(feature = "dummy")]
 mod dummy_handle;
+
 #[cfg(not(feature = "dummy"))]
 pub mod handle;
+
 #[cfg(feature = "dummy")]
 pub mod dummy_callback;
+
 #[cfg(not(feature = "dummy"))]
 pub mod callback;
 pub mod types;
+
 #[cfg(feature = "dummy")]
 pub mod dummy_input;
+
 #[cfg(not(feature = "dummy"))]
 pub mod input;
+
 #[cfg(feature="wlc-wayland")]
+#[cfg(feature="dummy")]
+pub mod dummy_wayland;
+
+#[cfg(feature="wlc-wayland")]
+#[cfg(not(feature="dummy"))]
 pub mod wayland;
+
 #[deprecated]
 pub mod xkb;
 
 pub use types::*;
+
 #[cfg(not(feature = "dummy"))]
 pub use handle::{WlcOutput, WlcView};
+
 #[cfg(feature = "dummy")]
 pub use dummy_handle::{WlcOutput, WlcView};
 
 #[cfg(feature="wlc-wayland")]
+#[cfg(not(feature = "dummy"))]
 pub use wayland::WlcResource;
+
+#[cfg(feature="wlc-wayland")]
+#[cfg(feature = "dummy")]
+pub use dummy_wayland::WlcResource;
 
 // Log Handler hack
 #[cfg(not(feature = "dummy"))]


### PR DESCRIPTION
This deprecates the "dummy-rustwlc" crate. This should be used instead for mocking and testing.

Another PR will add better mocking, eg a builder for the mock objects (specifically `WlcOutput` and `WlcView`)