### PR TITLE
Added binding for new mouse movements.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustwlc"
 description = "wlc Wayland library bindings for Rust"
-version = "0.6.5"
+version = "0.7.0"
 repository = "https://github.com/Immington-Industries/rust-wlc/"
 keywords = ["wlc", "Wayland", "compositor", "bindings"]
 readme = "README.md"

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -118,8 +118,12 @@ extern "C" {
     // Motion event was triggered, view handle will be zero if there was no
     // focus. Apply with wlc_pointer_set_position to agree. Return true to
     // prevent sending the event to clients.
+    #[deprecated(since="0.7.0", note="Use wlc_set_pointer_motion_cb_v2 instead")]
     fn wlc_set_pointer_motion_cb(cb: extern "C" fn(WlcView, u32,
                                                    &Point) -> bool);
+
+    fn wlc_set_pointer_motion_cb_v2(cb: extern "C" fn(WlcView, u32,
+                                                  f64, f64) -> bool);
 
     // Touch event was triggered, view handle will be zero if there was no
     // focus. Return true to prevent sending the event to clients.
@@ -507,12 +511,42 @@ pub fn pointer_scroll(callback: extern "C" fn(view: WlcView, time: u32,
 /// }
 /// # fn main() { }
 /// ```
+#[deprecated(since="0.7.0", note="Use pointer_motion_v2 instead")]
+#[allow(deprecated)]
 pub fn pointer_motion(callback: extern "C" fn(view: WlcView, time: u32,
                                               point: &Point) -> bool) {
     unsafe {
         wlc_set_pointer_motion_cb(callback);
     }
 }
+
+/// Callback invoked on pointer motion.
+/// Return `true` to block the motion from the view.
+///
+/// `rustwlc::input::pointer::set_position_v2`
+/// must be invoked to actually move the cursor!
+///
+/// # Example
+/// ```rust
+/// use rustwlc::WlcView;
+/// use rustwlc::Point;
+/// use rustwlc::input::pointer;
+///
+/// extern fn pointer_motion(view: WlcView, time: u32, x: f64, y: f64) -> bool {
+///     println!("Pointer was moved to {} {} in {:?} at {}", x, y, view, time);
+///     // This is very important.
+///     pointer::set_position_v2(x, y);
+///     return false;
+/// }
+/// # fn main() { }
+/// ```
+pub fn pointer_motion_v2(callback: extern "C" fn(view: WlcView, time: u32,
+                                              x: f64, y: f64) -> bool) {
+    unsafe {
+        wlc_set_pointer_motion_cb_v2(callback);
+    }
+}
+
 
 /// Callback invoked on touchscreen touch.
 /// Return `true` to block the touch from the view.

--- a/src/input.rs
+++ b/src/input.rs
@@ -16,9 +16,15 @@ extern "C" {
                                       modifiers: *const KeyboardModifiers) -> uint32_t;
 
     // Pointer functions
+    #[deprecated(since="0.7.0", note="Use wlc_pointer_get_position_v2 instead")]
     fn wlc_pointer_get_position(out_position: *mut Point);
 
+    fn wlc_pointer_get_position_v2(out_x: &mut f64, out_y: &mut f64);
+
+    #[deprecated(since="0.7.0", note="Use wlc_pointer_set_position_v2 instead")]
     fn wlc_pointer_set_position(position: *const Point);
+
+    fn wlc_pointer_set_position_v2(x: f64, y: f64);
 }
 
 pub mod pointer {
@@ -26,6 +32,8 @@ pub mod pointer {
     use super::super::types::{Point};
 
     /// Gets the current position of the mouse.
+    #[deprecated(since="0.7.0", note="Use get_position_v2()->(f64, f64) instead")]
+    #[allow(deprecated)]
     pub fn get_position() -> Point {
         unsafe {
             let mut point = Point { x: 0, y: 0 };
@@ -34,9 +42,27 @@ pub mod pointer {
         }
     }
 
+    /// Gets the current position of the mouse.
+    pub fn get_position_v2() -> (f64, f64){
+        let (mut x, mut y) = (0.0, 0.0);
+        unsafe{
+            super::wlc_pointer_get_position_v2(&mut x, &mut y);
+        }
+        (x, y)
+    }
+
     /// Sets the current mouse position. Required on mouse move callback.
+    #[deprecated(since="0.7.0", note="Use set_position_v2(x: f64, y: f64) instead")]
+    #[allow(deprecated)]
     pub fn set_position(point: Point) {
         unsafe { super::wlc_pointer_set_position(&point); }
+    }
+
+    /// Sets the current mouse position. Required on mouse move callback.
+    pub fn set_position_v2(x: f64, y: f64){
+        unsafe{
+            super::wlc_pointer_set_position_v2(x,y);
+        }
     }
 }
 


### PR DESCRIPTION
Set the old bindings as deprecated.
Ref: https://github.com/Cloudef/wlc/issues/181

New to git. I hope this works.
I also have a forked copy of way-cooler that uses the new bindings but it's been very badly hacked in.